### PR TITLE
feat: disable http2 in vanilla go app

### DIFF
--- a/vanilla-go-app/go.mod
+++ b/vanilla-go-app/go.mod
@@ -1,5 +1,3 @@
 module github.com/mattes/vanilla-go-app
 
 go 1.22.4
-
-require github.com/templarbit/vanilla-go-app v1.0.6

--- a/vanilla-go-app/go.sum
+++ b/vanilla-go-app/go.sum
@@ -1,2 +1,0 @@
-github.com/templarbit/vanilla-go-app v1.0.6 h1:R83vKnmjaUEF/73IlXveLRqtcFylixXz3tyB78KcIGw=
-github.com/templarbit/vanilla-go-app v1.0.6/go.mod h1:NcqKlTKHCfx2Oj6MnwWvhbrX1hgnQrDqJqdLoi2JaHI=

--- a/vanilla-go-app/main.go
+++ b/vanilla-go-app/main.go
@@ -1,3 +1,5 @@
+//go:debug http2server=0
+
 package main
 
 import (
@@ -17,7 +19,7 @@ import (
 
 func main() {
 	log.SetOutput(os.Stdout)
-	
+
 	listenFlag := flag.String("listen", ":8080", "Listen for connections on host:port")
 	httpKeepAliveFlag := flag.Bool("http-keep-alive", true, "Enable HTTP KeepAlive")
 	httpReadTimeoutFlag := flag.Duration("http-read-timeout", 10*time.Second, "ReadTimeout is the maximum duration for reading the entire request, including the body.")


### PR DESCRIPTION
because http2 connections can't be hijacked