### PR TITLE
Fixup the transfer encoding

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use base64::prelude::*;
 use clap::{ArgAction, Parser};
 use http_body_util::Full;
-use hyper::{body::Bytes, Request};
+use hyper::{body::Bytes, Request, Version};
 use hyper_util::rt::TokioIo;
 use pki_types::CertificateDer;
 use serde::Deserialize;
@@ -187,7 +187,8 @@ async fn prover(config: Config) -> Result<TlsProof> {
         let _enter = span.enter();
         let mut request = Request::builder()
             .method(config.target_method.as_str())
-            .uri(config.target_url);
+            .uri(config.target_url)
+            .version(Version::HTTP_10);
 
         let headers = request.headers_mut().unwrap();
         for (key, values) in config.target_headers {

--- a/vanilla-go-app/server/server.go
+++ b/vanilla-go-app/server/server.go
@@ -28,7 +28,7 @@ func Server() *http.ServeMux {
 	})
 
 	// Routes that return fixed KB of binary data
-	kb := []int{0, 1, 10, 100, 1000}
+	kb := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 16, 100, 1000}
 	for _, v := range kb {
 		b := make([]byte, v*1000)
 		_, err := rand.Read(b)
@@ -39,6 +39,7 @@ func Server() *http.ServeMux {
 		mux.HandleFunc("/bin/"+strconv.Itoa(v)+"KB",
 			func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/octet-stream")
+				w.Header().Set("Content-Length", strconv.Itoa(len(b)))
 				w.WriteHeader(200) // OK
 				w.Write(b)
 			})
@@ -47,6 +48,7 @@ func Server() *http.ServeMux {
 		mux.HandleFunc("/plain/"+strconv.Itoa(v)+"KB",
 			func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/plain")
+				w.Header().Set("Content-Length", strconv.Itoa(len(b64)))
 				w.WriteHeader(200) // OK
 				w.Write([]byte(b64))
 			})
@@ -114,6 +116,8 @@ func Server() *http.ServeMux {
 			w.WriteHeader(400) // Bad Request
 			return
 		}
+		
+		w.WriteHeader(200)
 		time.Sleep(time.Duration(ms) * time.Millisecond)
 
 		hj, ok := w.(http.Hijacker)


### PR DESCRIPTION
When request size goes >2kb server switches to chunked responses. This is not supported by the notarized req/resp HTTP parser. We could fix the parser, but that is pain. Instead opt for HTTP 1.0 (instead of 1.1) which doesn't support chunking. Without chunking, the server must return a content-length, so add in those headers.


It's not obvious to me right now if adding "transfer-encoding" support would also require changes to MPC-TLS or if this is purely a "spansy" parser problem. I suspect it is the latter, but given this isn't our top priority, just fix it this hacky way. 

fixes #14 