### PR TITLE
ci: remove duplicate workflows

### DIFF
--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -1,5 +1,9 @@
 name: client
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/client_ios.yaml
+++ b/.github/workflows/client_ios.yaml
@@ -1,5 +1,9 @@
 name: client_ios
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/client_wasm.yaml
+++ b/.github/workflows/client_wasm.yaml
@@ -1,5 +1,9 @@
 name: client_wasm
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,11 @@
 # Process: make small changes, push them, check the Actions tab on github
 # also see templates https://github.com/rust-github/template/tree/main/.github/workflows
 name: Lint
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]
@@ -28,7 +33,7 @@ jobs:
           profile: minimal
           components: clippy
           override: true
-      
+
       - name: cargo clippy
         run: cargo clippy
 
@@ -45,4 +50,4 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
-    
+

--- a/.github/workflows/notary.yaml
+++ b/.github/workflows/notary.yaml
@@ -1,5 +1,9 @@
 name: notary
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/proofs_test.yaml
+++ b/.github/workflows/proofs_test.yaml
@@ -1,5 +1,9 @@
 name: tests/proofs
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
closes #235 

- runs workflows on only push/PR to main
- cancels in-progress workflows on new events