### PR TITLE
perf: release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,11 +46,11 @@ tokio-tungstenite="0.23.0"
 serde            ={ version="1.0.204", features=["derive"] }
 serde_json       ="1.0.120"
 
-# TODO (autoparallel): I commented this out because it makes testing in release mode build really slow
-# [profile.release]
-# opt-level=2
-# lto      =true
-
-# TODO how to get symbols for debugging (stack trace) into wasm module in --release mode?
-# [profile.release]
-# debug = true
+# More information here: https://doc.rust-lang.org/cargo/reference/profiles.html
+[profile.release]
+opt-level    =3
+lto          ="fat"
+codegen-units=1
+panic        ="abort"
+strip        =true
+debug        =true    # Propagate more information up through FFI


### PR DESCRIPTION
Closes #296 

Optimizes for the fastest running binary. Also sets `debug` to true so this information can be provided to iOS/WASM as needed. (I believe we wanted this.)