### PR TITLE
fix: Remove inlined circuit data bytes

### DIFF
--- a/client/src/errors.rs
+++ b/client/src/errors.rs
@@ -99,6 +99,9 @@ pub enum ClientErrors {
   #[error(transparent)]
   Canceled(#[from] futures::channel::oneshot::Canceled),
 
+  #[error("Missing setup data")]
+  MissingSetupData,
+
   #[error("Manifest missing")]
   ManifestMissingError,
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -16,9 +16,11 @@ mod tls;
 pub mod tls_client_async2;
 use std::collections::HashMap;
 
+use origo::SignedVerificationReply;
+pub use proofs::program::data::UninitializedSetup;
 use proofs::{
   circuits::{construct_setup_data_from_fs, CIRCUIT_SIZE_512},
-  program::{data::UninitializedSetup, manifest::NIVCRom},
+  program::manifest:: NIVCRom},
   proof::FoldingProof,
 };
 use serde::{Deserialize, Serialize};

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -16,7 +16,11 @@ mod tls;
 pub mod tls_client_async2;
 use std::collections::HashMap;
 
-use proofs::{program::manifest::NIVCRom, proof::FoldingProof};
+use proofs::{
+  circuits::{construct_setup_data_from_fs, CIRCUIT_SIZE_512},
+  program::{data::UninitializedSetup, manifest::NIVCRom},
+  proof::FoldingProof,
+};
 use serde::{Deserialize, Serialize};
 pub use tlsn_core::proof::TlsProof;
 use tlsn_prover::tls::ProverConfig;
@@ -52,11 +56,12 @@ pub fn get_web_prover_circuits_version() -> String {
 pub async fn prover_inner(
   config: config::Config,
   proving_params: Option<Vec<u8>>,
+  setup_data: Option<UninitializedSetup>,
 ) -> Result<Proof, ClientErrors> {
   info!("GIT_HASH: {}", env!("GIT_HASH"));
   match config.mode {
     config::NotaryMode::TLSN => prover_inner_tlsn(config).await,
-    config::NotaryMode::Origo => prover_inner_origo(config, proving_params).await,
+    config::NotaryMode::Origo => prover_inner_origo(config, proving_params, setup_data).await,
     config::NotaryMode::TEE => prover_inner_tee(config).await,
     config::NotaryMode::Proxy => prover_inner_proxy(config).await,
   }
@@ -99,10 +104,22 @@ pub async fn prover_inner_tlsn(mut config: config::Config) -> Result<Proof, Clie
 pub async fn prover_inner_origo(
   config: config::Config,
   proving_params: Option<Vec<u8>>,
+  setup_data: Option<UninitializedSetup>,
 ) -> Result<Proof, ClientErrors> {
   let session_id = config.session_id.clone();
 
-  let mut proof = origo::proxy_and_sign_and_generate_proof(config.clone(), proving_params).await?;
+  let setup_data = if let Some(setup_data) = setup_data {
+    Ok(setup_data)
+  } else if !cfg!(target_os = "ios") && !cfg!(target_arch = "wasm32") {
+    // TODO: How do we decide which CIRCUIT_SIZE_* to use here?
+    construct_setup_data_from_fs::<CIRCUIT_SIZE_512>()
+      .map_err(|e| ClientErrors::Other(e.to_string()))
+  } else {
+    Err(ClientErrors::MissingSetupData)
+  }?;
+
+  let mut proof =
+    origo::proxy_and_sign_and_generate_proof(config.clone(), proving_params, setup_data).await?;
 
   let manifest = config.proving.manifest.clone().ok_or(ClientErrors::ManifestMissingError)?;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -16,11 +16,10 @@ mod tls;
 pub mod tls_client_async2;
 use std::collections::HashMap;
 
-use origo::SignedVerificationReply;
 pub use proofs::program::data::UninitializedSetup;
 use proofs::{
   circuits::{construct_setup_data_from_fs, CIRCUIT_SIZE_512},
-  program::manifest:: NIVCRom},
+  program::manifest::NIVCRom,
   proof::FoldingProof,
 };
 use serde::{Deserialize, Serialize};

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -33,8 +33,8 @@ async fn main() -> Result<(), ClientErrors> {
   let mut config: Config = serde_json::from_str(&config_json)?;
   config.set_session_id();
 
-  let proving_params = std::fs::read(proofs::circuits::PROVING_PARAMS_512).unwrap();
-  let proof = client::prover_inner(config, Some(proving_params)).await?;
+  let proving_params = std::fs::read(proofs::circuits::PROVING_PARAMS_512)?;
+  let proof = client::prover_inner(config, Some(proving_params), None).await?;
   let proof_json = serde_json::to_string_pretty(&proof)?;
   println!("Proving Successful: proof_len={:?}", proof_json.len());
   Ok(())

--- a/client/src/origo.rs
+++ b/client/src/origo.rs
@@ -138,7 +138,6 @@ pub(crate) async fn proxy_and_sign_and_generate_proof(
 
   let _sign_data = crate::origo::sign(config.clone(), session_id.clone(), sb).await;
 
-  debug!("generating program data!");
   let witness = origo_conn.to_witness_data();
 
   // decrypt TLS ciphertext for request and response and create NIVC inputs
@@ -175,7 +174,7 @@ pub(crate) async fn generate_proof(
   request_inputs: &EncryptionInput,
   response_inputs: &EncryptionInput,
 ) -> Result<OrigoProof, ClientErrors> {
-  let program_data = SetupParams::<Offline> {
+  let setup_params = SetupParams::<Offline> {
     public_params:       proving_params.to_vec(),
     vk_digest_primary:   F::<G1>::from(0), // These need to be right.
     vk_digest_secondary: F::<G2>::from(0),
@@ -184,15 +183,15 @@ pub(crate) async fn generate_proof(
   }
   .into_online()?;
 
-  let vk_digest_primary = program_data.vk_digest_primary;
-  let vk_digest_secondary = program_data.vk_digest_secondary;
+  let vk_digest_primary = setup_params.vk_digest_primary;
+  let vk_digest_secondary = setup_params.vk_digest_secondary;
   crate::proof::construct_program_data_and_proof::<{ proofs::circuits::CIRCUIT_SIZE_512 }>(
     manifest,
     request_inputs,
     response_inputs,
     (vk_digest_primary, vk_digest_secondary),
-    program_data.public_params,
-    program_data.setup_data,
+    setup_params.public_params,
+    setup_params.setup_data,
   )
   .await
 

--- a/client_ios/src/lib.rs
+++ b/client_ios/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use client::config::Config;
-use proofs::circuits::PROVING_PARAMS_BYTES_512;
+use proofs::circuits::load_proving_params_512;
 use tracing::debug;
 
 #[derive(serde::Serialize)]
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn prover(config_json: *const c_char) -> *const c_char {
     debug!("starting proving");
 
     let proof =
-      rt.block_on(client::prover_inner(config, Some(PROVING_PARAMS_BYTES_512.to_vec()))).unwrap();
+      rt.block_on(client::prover_inner(config, Some(load_proving_params_512().unwrap()))).unwrap();
     debug!("done proving: {:?}", Instant::now() - start);
     serde_json::to_string_pretty(&proof).unwrap()
   }));

--- a/client_ios/src/lib.rs
+++ b/client_ios/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use client::config::Config;
-use proofs::circuits::load_proving_params_512;
+use proofs::circuits::{construct_setup_data_from_fs, load_proving_params_512};
 use tracing::debug;
 
 #[derive(serde::Serialize)]
@@ -43,8 +43,14 @@ pub unsafe extern "C" fn prover(config_json: *const c_char) -> *const c_char {
     let start = Instant::now();
     debug!("starting proving");
 
-    let proof =
-      rt.block_on(client::prover_inner(config, Some(load_proving_params_512().unwrap()))).unwrap();
+    let proof = rt
+      .block_on(client::prover_inner(
+        config,
+        // TODO: Do I pass these here from `prover` call args or just make Some(...) in-place?
+        Some(load_proving_params_512().unwrap()),
+        Some(construct_setup_data_from_fs::<512>().unwrap()),
+      ))
+      .unwrap();
     debug!("done proving: {:?}", Instant::now() - start);
     serde_json::to_string_pretty(&proof).unwrap()
   }));

--- a/client_wasm/Cargo.toml
+++ b/client_wasm/Cargo.toml
@@ -9,7 +9,7 @@ publish=false
 crate-type=["cdylib", "rlib"]
 
 [dependencies]
-client              ={ workspace=true, features=["websocket"] }
+client              ={ workspace=true, features=["websocket", "unsafe_skip_cert_verification"] }
 js-sys              ="0.3.64"
 serde-wasm-bindgen  ="0.6.1"
 serde_json          ={ workspace=true }

--- a/client_wasm/Cargo.toml
+++ b/client_wasm/Cargo.toml
@@ -9,7 +9,7 @@ publish=false
 crate-type=["cdylib", "rlib"]
 
 [dependencies]
-client              ={ workspace=true, features=["websocket", "unsafe_skip_cert_verification"] }
+client              ={ workspace=true, features=["websocket"] }
 js-sys              ="0.3.64"
 serde-wasm-bindgen  ="0.6.1"
 serde_json          ={ workspace=true }

--- a/client_wasm/demo/js/index.js
+++ b/client_wasm/demo/js/index.js
@@ -60,6 +60,9 @@ const getBytes = async function (file) {
   ).toString();
   const buffer = await fetch(ppUrl).then((r) => r.arrayBuffer());
   console.log("buffer.byteLength", buffer.byteLength);
+  if (buffer.byteLength === 0) {
+    throw new Error(`Failed to load ${file}`);
+  }
   return new Uint8Array(buffer); // Cast to a js-sys (WASM) friendly type
 };
 

--- a/client_wasm/demo/js/index.js
+++ b/client_wasm/demo/js/index.js
@@ -1,4 +1,5 @@
 import init, {setup_tracing, initThreadPool} from "../pkg/client_wasm.js";
+import { witness } from "./witness"; // This is not unused, this is how we initialize window.witness
 import { WEB_PROVER_CIRCUITS_VERSION } from "./config";
 
 const numConcurrency = navigator.hardwareConcurrency;

--- a/client_wasm/demo/js/index.js
+++ b/client_wasm/demo/js/index.js
@@ -1,5 +1,4 @@
-import init, { setup_tracing, initThreadPool } from "../pkg/client_wasm.js";
-import { witness } from "./witness";
+import init, {setup_tracing, initThreadPool} from "../pkg/client_wasm.js";
 import { WEB_PROVER_CIRCUITS_VERSION } from "./config";
 
 const numConcurrency = navigator.hardwareConcurrency;
@@ -19,13 +18,13 @@ function startMemoryMonitoring(instance) {
   }, 5000);
 }
 // Create a WebAssembly.Memory object
-const shared_memory = new WebAssembly.Memory({
+const sharedMemory = new WebAssembly.Memory({
   initial: 16384, // 256 pages = 16MB
   maximum: 40000, // 1024 pages = 64MB
   shared: true, // Enable shared memory
 });
 
-await init(undefined, shared_memory);
+await init(undefined, sharedMemory);
 setup_tracing("debug,tlsn_extension_rs=debug");
 await initThreadPool(numConcurrency);
 console.log("initialized thread pool", numConcurrency);
@@ -33,9 +32,9 @@ console.log(`Thread pool initialized with ${numConcurrency} threads`);
 if (navigator.hardwareConcurrency) {
   console.log(`Hardware concurrency: ${navigator.hardwareConcurrency}`);
 }
-startMemoryMonitoring(shared_memory);
+startMemoryMonitoring(sharedMemory);
 
-var startTime, endTime, startPreWitgenTime;
+let startTime, endTime, startPreWitgenTime;
 
 function start() {
   startTime = performance.now();
@@ -43,24 +42,24 @@ function start() {
 
 function end() {
   endTime = performance.now();
-  var timeDiff = endTime - startTime;
+  let timeDiff = endTime - startTime;
   timeDiff /= 1000;
 
-  var timeDiffWitgen = endTime - startPreWitgenTime;
+  let timeDiffWitgen = endTime - startPreWitgenTime;
   timeDiffWitgen /= 1000;
 
   console.log(Math.round(timeDiff) + " seconds");
   console.log(Math.round(timeDiffWitgen) + " seconds (including witness)");
 }
 
-const getByteParams = async function (setupFile) {
+const getBytes = async function (file) {
   const ppUrl = new URL(
-    `build/${setupFile}`,
+    `build/${file}`,
     window.location.origin,
   ).toString();
-  const pp = await fetch(ppUrl).then((r) => r.arrayBuffer());
-  console.log("byte_params", pp);
-  return pp;
+  const buffer = await fetch(ppUrl).then((r) => r.arrayBuffer());
+  console.log("byte_params", buffer);
+  return new Uint8Array(buffer); // Cast to a js-sys (WASM) friendly type
 };
 
 start();
@@ -73,15 +72,24 @@ const proofWorker = new Worker(new URL("./proof.js", import.meta.url), {
 console.log("sending message to worker");
 console.log(WEB_PROVER_CIRCUITS_VERSION)
 
-var proving_params = {
-  aux_params: await getByteParams(
-    `circom-artifacts-512b-v${WEB_PROVER_CIRCUITS_VERSION}/serialized_setup_512b_rom_length_100.bin`,
-  ),
+function artifactPath(name) {
+  return `circom-artifacts-512b-v${WEB_PROVER_CIRCUITS_VERSION}/${name}`;
+}
+
+const provingParams = {
+  aux_params: await getBytes(artifactPath('serialized_setup_512b_rom_length_100.bin')),
 };
+const r1csTypes = [
+  await getBytes(artifactPath('plaintext_authentication_512b.r1cs')),
+  await getBytes(artifactPath('http_verification_512b.r1cs')),
+  await getBytes(artifactPath('json_extraction_512b.r1cs')),
+];
+
 proofWorker.postMessage({
   proverConfig,
-  proving_params,
-  shared_memory,
+  provingParams,
+  r1csTypes,
+  sharedMemory,
 });
 console.log("message sent to worker");
 proofWorker.onmessage = (event) => {
@@ -90,7 +98,7 @@ proofWorker.onmessage = (event) => {
   } else if (event.data.type === "log") {
     console.log(...event.data.data);
   } else {
-    if ("type" in event.data && event.data.type == "proof") {
+    if ("type" in event.data && event.data.type === "proof") {
       console.log("proof successfully generated: ", event.data);
     } else {
       console.error("Error from worker:", event.data)

--- a/client_wasm/demo/js/index.js
+++ b/client_wasm/demo/js/index.js
@@ -20,8 +20,8 @@ function startMemoryMonitoring(instance) {
 }
 // Create a WebAssembly.Memory object
 const sharedMemory = new WebAssembly.Memory({
-  initial: 16384, // 256 pages = 16MB
-  maximum: 40000, // 1024 pages = 64MB
+  initial: 16384, // 16,384 pages = 1GB
+  maximum: 49152, // 49,152 pages = 3GB
   shared: true, // Enable shared memory
 });
 

--- a/client_wasm/demo/js/index.js
+++ b/client_wasm/demo/js/index.js
@@ -59,7 +59,7 @@ const getBytes = async function (file) {
     window.location.origin,
   ).toString();
   const buffer = await fetch(ppUrl).then((r) => r.arrayBuffer());
-  console.log("byte_params", buffer);
+  console.log("buffer.byteLength", buffer.byteLength);
   return new Uint8Array(buffer); // Cast to a js-sys (WASM) friendly type
 };
 

--- a/client_wasm/demo/js/proof.js
+++ b/client_wasm/demo/js/proof.js
@@ -1,4 +1,4 @@
-import init, { prover, ProvingParamsWasm } from '../pkg/client_wasm'
+import init, { prover, ProvingParamsWasm, UninitializedSetupWasm } from '../pkg/client_wasm'
 import { witness } from './witness'
 
 // Override console.log and console.error
@@ -17,20 +17,17 @@ console.error = (...args) => {
 
 postMessage({ type: 'status', data: 'Worker running' })
 
-var startTime, endTime
+let startTimeMs, endTimeMs;
 
 function start() {
-  startTime = performance.now()
+  startTimeMs = performance.now()
 }
 
 function end() {
-  endTime = performance.now()
-  var timeDiff = endTime - startTime //in ms
-  // strip the ms
-  timeDiff /= 1000
+  endTimeMs = performance.now()
+  const timeDiffMs = endTimeMs - startTimeMs;
 
-  // get seconds
-  var seconds = Math.round(timeDiff)
+  const seconds = Math.round(timeDiffMs/1000);
   console.log('worker thread:', seconds + ' seconds')
 }
 
@@ -43,33 +40,39 @@ function checkWorkerMemory() {
 self.onmessage = async function (e) {
   try {
     console.log('Worker: Starting proof generation')
-    const { proverConfig, proving_params, shared_memory } = e.data
+    const { proverConfig, provingParams, r1csTypes, sharedMemory } = e.data
     console.log('Worker: Got message data')
 
     self.witness = witness
     console.log('Worker: Set witness')
 
     console.log('Worker: Initializing...')
-    await init(undefined, shared_memory)
+    await init(undefined, sharedMemory)
     console.log('Worker: Initialized')
 
     start()
     console.log('Worker: Creating ProvingParamsWasm')
-    var pp = new ProvingParamsWasm(new Uint8Array(proving_params.aux_params))
+    const pp = new ProvingParamsWasm(new Uint8Array(provingParams.aux_params))
     console.log('Worker: Created ProvingParamsWasm')
+
+    console.log('Worker: Creating UninitializedSetupWasm')
+    const setupData = new UninitializedSetupWasm(r1csTypes)
+    console.log('Worker: Created UninitializedSetupWasm')
 
     checkWorkerMemory()
     console.log('Worker: Starting prover')
-    const proof = await prover(proverConfig, pp)
+    const proof = await prover(proverConfig, pp, setupData)
     checkWorkerMemory()
     console.log('Worker: Prover completed')
 
     console.log('sending proof back to main thread')
     end()
     postMessage({ type: 'proof', data: proof })
+    self.close()
   } catch (error) {
     console.error('Error in worker:', error)
     console.error('Error stack:', error.stack) // Add stack trace
     postMessage({ type: 'error', data: error.message })
+    self.close()
   }
 }

--- a/client_wasm/demo/js/witness.js
+++ b/client_wasm/demo/js/witness.js
@@ -62,7 +62,13 @@ export const witness = {
   createWitness: async (input, rom) => {
     console.log("createWitness", input);
     console.log("rom", rom);
-    var witnesses = await generateWitnessBytes(input, rom);
+    if (!input) {
+      throw new Error("Input is undefined");
+    }
+    if (!rom) {
+      throw new Error("ROM is undefined");
+    }
+    let witnesses = await generateWitnessBytes(input, rom);
     let witnesses_typed = new WitnessOutput(witnesses);
     console.log("witness", witnesses_typed);
     return witnesses_typed;

--- a/client_wasm/src/lib.rs
+++ b/client_wasm/src/lib.rs
@@ -1,6 +1,6 @@
 use std::panic;
 
-use client::config::Config;
+use client::{config::Config, UninitializedSetup};
 use tlsn_core::proof::TlsProof;
 use tracing::debug;
 use tracing_subscriber::{
@@ -33,17 +33,51 @@ impl ProvingParamsWasm {
 }
 
 #[wasm_bindgen]
-pub async fn prover(config: JsValue, proving_params: ProvingParamsWasm) -> Result<String, JsValue> {
+pub struct UninitializedSetupWasm {
+  pub(crate) r1cs_types:              Vec<js_sys::Uint8Array>,
+  pub(crate) witness_generator_types: Vec<js_sys::Uint8Array>,
+}
+
+#[wasm_bindgen]
+impl UninitializedSetupWasm {
+  #[wasm_bindgen(constructor)]
+  pub fn new(
+    r1cs_types: Vec<js_sys::Uint8Array>,
+    witness_generator_types: Vec<js_sys::Uint8Array>,
+  ) -> Self {
+    Self { r1cs_types, witness_generator_types }
+  }
+}
+
+impl UninitializedSetupWasm {
+  pub fn to_canonical(&self) -> UninitializedSetup {
+    let r1cs_types = self.r1cs_types.iter().map(|r1cs| r1cs.to_vec()).collect();
+    let witness_generator_types =
+      self.witness_generator_types.iter().map(|wgt| wgt.to_vec()).collect();
+    UninitializedSetup::from_raw_parts(r1cs_types, witness_generator_types)
+  }
+}
+
+#[wasm_bindgen]
+pub async fn prover(
+  config: JsValue,
+  proving_params: ProvingParamsWasm,
+  setup_data: UninitializedSetupWasm,
+) -> Result<String, JsValue> {
   panic::set_hook(Box::new(console_error_panic_hook::hook));
 
   debug!("start config serde");
-  let mut config: Config = serde_wasm_bindgen::from_value(config).unwrap(); // TODO replace unwrap
+  let mut config: Config = serde_wasm_bindgen::from_value(config)?;
   config.set_session_id();
   debug!("end config serde");
 
-  let proof = client::prover_inner(config, Some(proving_params.aux_params.to_vec()))
-    .await
-    .map_err(|e| JsValue::from_str(&format!("Could not produce proof: {:?}", e)))?;
+  let proof = client::prover_inner(
+    config,
+    Some(proving_params.aux_params.to_vec()),
+    Some(setup_data.to_canonical()),
+  )
+  .await
+  .map_err(|e| JsValue::from_str(&format!("Could not produce proof: {:?}", e)))?;
 
   serde_json::to_string_pretty(&proof)
     .map_err(|e| JsValue::from_str(&format!("Could not serialize proof: {:?}", e)))

--- a/notary/src/verifier.rs
+++ b/notary/src/verifier.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 
 use client_side_prover::supernova::snark::{CompressedSNARK, VerifierKey};
 use proofs::{
-  circuits::{construct_setup_data, PROVING_PARAMS_512},
+  circuits::{construct_setup_data_from_fs, PROVING_PARAMS_512},
   program::data::{CircuitData, Offline, Online, SetupParams},
   E1, F, G1, G2, S1, S2,
 };
@@ -36,7 +36,7 @@ pub fn flatten_rom(rom: Vec<String>) -> Vec<String> {
 
 pub fn initialize_verifier() -> Result<Verifier, ProxyError> {
   let bytes = std::fs::read(PROVING_PARAMS_512)?;
-  let setup_data = construct_setup_data::<{ proofs::circuits::CIRCUIT_SIZE_512 }>()?;
+  let setup_data = construct_setup_data_from_fs::<{ proofs::circuits::CIRCUIT_SIZE_512 }>()?;
   let rom_data = HashMap::from([
     (String::from("PLAINTEXT_AUTHENTICATION"), CircuitData { opcode: 0 }),
     (String::from("HTTP_VERIFICATION"), CircuitData { opcode: 1 }),

--- a/proofs/src/circom/wasm_witness.rs
+++ b/proofs/src/circom/wasm_witness.rs
@@ -25,12 +25,12 @@ pub async fn create_witness(input: JsValue, opcode: u64) -> Result<WitnessOutput
   let js_witnesses_output = create_witness_js(&input, opcode).await;
 
   // Call JavaScript function and await the Promise
-  info!("result: {:?}", js_witnesses_output);
+  info!("js_witnesses_output: {:?}", js_witnesses_output);
   let js_obj = js_sys::Object::from(js_witnesses_output);
   let data_value = js_sys::Reflect::get(&js_obj, &JsValue::from_str("data"))?;
   let array = js_sys::Array::from(&data_value);
   let data = js_sys::Uint8Array::new(&array);
 
-  debug!("data: {:?}", data);
+  debug!("js_witnesses_output as data: {:?}", data);
   Ok(WitnessOutput { data })
 }

--- a/proofs/src/circuits.rs
+++ b/proofs/src/circuits.rs
@@ -34,17 +34,6 @@ pub fn load_proving_params_512() -> Result<Vec<u8>, std::io::Error> {
   // TODO: A stub for iOS
   load_artifact_bytes(PROVING_PARAMS_512)
 }
-// pub const PROVING_PARAMS_256: &str = concat!(
-//   "proofs/web_proof_circuits/circom-artifacts-256b-v",
-//   env!("WEB_PROVER_CIRCUITS_VERSION"),
-//   "/serialized_setup_256b_rom_length_100.bin"
-// );
-// #[cfg(not(target_arch = "wasm32"))]
-// pub const PROVING_PARAMS_BYTES_256: &str = concat!(
-//   "proofs/web_proof_circuits/circom-artifacts-256b-v",
-//   env!("WEB_PROVER_CIRCUITS_VERSION"),
-//   "/serialized_setup_256b_rom_length_100.bin"
-// );
 
 // -------------------------------------- 512B circuits -------------------------------------- //
 /// Circuit 0

--- a/proofs/src/circuits.rs
+++ b/proofs/src/circuits.rs
@@ -14,7 +14,9 @@ use crate::{
 // -------------------------------------- circuits -------------------------------------- //
 /// Maximum ROM length
 pub const MAX_ROM_LENGTH: usize = 100;
-/// Circuit size
+/// Circuit size 256
+pub const CIRCUIT_SIZE_256: usize = 256;
+/// Circuit size 512
 pub const CIRCUIT_SIZE_512: usize = 512;
 /// Public input variables
 pub const PUBLIC_IO_VARS: usize = 11;
@@ -30,7 +32,7 @@ pub const PROVING_PARAMS_512: &str = concat!(
 #[cfg(not(target_arch = "wasm32"))]
 pub fn load_proving_params_512() -> Result<Vec<u8>, std::io::Error> {
   // TODO: A stub for iOS
-  load_bytes(PROVING_PARAMS_512)
+  load_artifact_bytes(PROVING_PARAMS_512)
 }
 // pub const PROVING_PARAMS_256: &str = concat!(
 //   "proofs/web_proof_circuits/circom-artifacts-256b-v",
@@ -143,7 +145,7 @@ fn wasm_witness_generator_type_512b() -> [WitnessGeneratorType; 3] {
   ]
 }
 
-fn load_bytes(path: &str) -> Result<Vec<u8>, std::io::Error> {
+pub fn load_artifact_bytes(path: &str) -> Result<Vec<u8>, std::io::Error> {
   let workspace_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
   let artifact_path = workspace_path.join(path);
   fs::read(artifact_path)
@@ -158,28 +160,28 @@ pub fn construct_setup_data_from_fs<const CIRCUIT_SIZE: usize>(
 ) -> Result<UninitializedSetup, ProofError> {
   let r1cs_types = match CIRCUIT_SIZE {
     CIRCUIT_SIZE_256 => vec![
-      R1CSType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_256B_R1CS)?),
-      R1CSType::Raw(load_bytes(HTTP_VERIFICATION_256B_R1CS)?),
-      R1CSType::Raw(load_bytes(JSON_EXTRACTION_256B_R1CS)?),
+      R1CSType::Raw(load_artifact_bytes(PLAINTEXT_AUTHENTICATION_256B_R1CS)?),
+      R1CSType::Raw(load_artifact_bytes(HTTP_VERIFICATION_256B_R1CS)?),
+      R1CSType::Raw(load_artifact_bytes(JSON_EXTRACTION_256B_R1CS)?),
     ],
     CIRCUIT_SIZE_512 => vec![
-      R1CSType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_512B_R1CS)?),
-      R1CSType::Raw(load_bytes(HTTP_VERIFICATION_512B_R1CS)?),
-      R1CSType::Raw(load_bytes(JSON_EXTRACTION_512B_R1CS)?),
+      R1CSType::Raw(load_artifact_bytes(PLAINTEXT_AUTHENTICATION_512B_R1CS)?),
+      R1CSType::Raw(load_artifact_bytes(HTTP_VERIFICATION_512B_R1CS)?),
+      R1CSType::Raw(load_artifact_bytes(JSON_EXTRACTION_512B_R1CS)?),
     ],
     _ => return Err(ProofError::InvalidCircuitSize),
   };
 
   let witness_generator_types = match CIRCUIT_SIZE {
     CIRCUIT_SIZE_256 => vec![
-      WitnessGeneratorType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_256B_GRAPH)?),
-      WitnessGeneratorType::Raw(load_bytes(HTTP_VERIFICATION_256B_GRAPH)?),
-      WitnessGeneratorType::Raw(load_bytes(JSON_EXTRACTION_256B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_artifact_bytes(PLAINTEXT_AUTHENTICATION_256B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_artifact_bytes(HTTP_VERIFICATION_256B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_artifact_bytes(JSON_EXTRACTION_256B_GRAPH)?),
     ],
     CIRCUIT_SIZE_512 => vec![
-      WitnessGeneratorType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_512B_GRAPH)?),
-      WitnessGeneratorType::Raw(load_bytes(HTTP_VERIFICATION_512B_GRAPH)?),
-      WitnessGeneratorType::Raw(load_bytes(JSON_EXTRACTION_512B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_artifact_bytes(PLAINTEXT_AUTHENTICATION_512B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_artifact_bytes(HTTP_VERIFICATION_512B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_artifact_bytes(JSON_EXTRACTION_512B_GRAPH)?),
     ],
     _ => return Err(ProofError::InvalidCircuitSize),
   };

--- a/proofs/src/circuits.rs
+++ b/proofs/src/circuits.rs
@@ -73,33 +73,39 @@ pub const JSON_EXTRACTION_512B_GRAPH: &str = concat!(
   "/json_extraction_512b.bin"
 );
 
+/// Plaintext authentication 256b R1CS
 const PLAINTEXT_AUTHENTICATION_256B_R1CS: &str = concat!(
   "proofs/web_proof_circuits/circom-artifacts-256b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/plaintext_authentication_256b.r1cs"
 );
+/// Plaintext authentication 256b graph
 const PLAINTEXT_AUTHENTICATION_256B_GRAPH: &str = concat!(
   "proofs/web_proof_circuits/circom-artifacts-256b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/plaintext_authentication_256b.bin"
 );
 // Circuit 1
+/// HTTP verification 256b R1CS
 const HTTP_VERIFICATION_256B_R1CS: &str = concat!(
   "proofs/web_proof_circuits/circom-artifacts-256b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/http_verification_256b.r1cs"
 );
+/// HTTP verification 256b graph
 const HTTP_VERIFICATION_256B_GRAPH: &str = concat!(
   "proofs/web_proof_circuits/circom-artifacts-256b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/http_verification_256b.bin"
 );
 // Circuit 2
+/// JSON extraction 256b R1CS
 const JSON_EXTRACTION_256B_R1CS: &str = concat!(
   "proofs/web_proof_circuits/circom-artifacts-256b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/json_extraction_256b.r1cs"
 );
+/// JSON extraction 256b graph
 const JSON_EXTRACTION_256B_GRAPH: &str = concat!(
   "proofs/web_proof_circuits/circom-artifacts-256b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
@@ -134,6 +140,7 @@ fn wasm_witness_generator_type_512b() -> [WitnessGeneratorType; 3] {
   ]
 }
 
+/// Loads artifact bytes from a given path relative to the workspace root
 pub fn load_artifact_bytes(path: &str) -> Result<Vec<u8>, std::io::Error> {
   let workspace_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
   let artifact_path = workspace_path.join(path);

--- a/proofs/src/circuits.rs
+++ b/proofs/src/circuits.rs
@@ -3,6 +3,9 @@
 //! - Plaintext authentication: ChaCha encryption
 //! - HTTP verification: HTTP parsing and locking
 //! - JSON extraction: JSON value extraction
+
+use std::{fs, path::PathBuf};
+
 use crate::{
   errors::ProofError,
   program::data::{R1CSType, UninitializedSetup, WitnessGeneratorType},
@@ -23,51 +26,94 @@ pub const PROVING_PARAMS_512: &str = concat!(
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/serialized_setup_512b_rom_length_100.bin"
 );
-/// Proving parameters bytes  
+/// Proving parameters bytes
 #[cfg(not(target_arch = "wasm32"))]
-pub const PROVING_PARAMS_BYTES_512: &[u8] = include_bytes!(concat!(
-  "../../proofs/web_proof_circuits/circom-artifacts-512b-v",
-  env!("WEB_PROVER_CIRCUITS_VERSION"),
-  "/serialized_setup_512b_rom_length_100.bin"
-));
+pub fn load_proving_params_512() -> Result<Vec<u8>, std::io::Error> {
+  // TODO: A stub for iOS
+  load_bytes(PROVING_PARAMS_512)
+}
+// pub const PROVING_PARAMS_256: &str = concat!(
+//   "proofs/web_proof_circuits/circom-artifacts-256b-v",
+//   env!("WEB_PROVER_CIRCUITS_VERSION"),
+//   "/serialized_setup_256b_rom_length_100.bin"
+// );
+// #[cfg(not(target_arch = "wasm32"))]
+// pub const PROVING_PARAMS_BYTES_256: &str = concat!(
+//   "proofs/web_proof_circuits/circom-artifacts-256b-v",
+//   env!("WEB_PROVER_CIRCUITS_VERSION"),
+//   "/serialized_setup_256b_rom_length_100.bin"
+// );
 
 // -------------------------------------- 512B circuits -------------------------------------- //
 /// Circuit 0
-pub const PLAINTEXT_AUTHENTICATION_512B_R1CS: &[u8] = include_bytes!(concat!(
-  "../../proofs/web_proof_circuits/circom-artifacts-512b-v",
+pub const PLAINTEXT_AUTHENTICATION_512B_R1CS: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-512b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/plaintext_authentication_512b.r1cs"
-));
+);
 /// Plaintext authentication 512b graph
-pub const PLAINTEXT_AUTHENTICATION_512B_GRAPH: &[u8] = include_bytes!(concat!(
-  "../../proofs/web_proof_circuits/circom-artifacts-512b-v",
+pub const PLAINTEXT_AUTHENTICATION_512B_GRAPH: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-512b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/plaintext_authentication_512b.bin"
-));
+);
 /// Circuit 1
-pub const HTTP_VERIFICATION_512B_R1CS: &[u8] = include_bytes!(concat!(
-  "../../proofs/web_proof_circuits/circom-artifacts-512b-v",
+pub const HTTP_VERIFICATION_512B_R1CS: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-512b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/http_verification_512b.r1cs"
-));
+);
 /// HTTP verification 512b graph
-pub const HTTP_VERIFICATION_512B_GRAPH: &[u8] = include_bytes!(concat!(
-  "../../proofs/web_proof_circuits/circom-artifacts-512b-v",
+pub const HTTP_VERIFICATION_512B_GRAPH: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-512b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/http_verification_512b.bin"
-));
+);
 /// Circuit 2
-pub const JSON_EXTRACTION_512B_R1CS: &[u8] = include_bytes!(concat!(
-  "../../proofs/web_proof_circuits/circom-artifacts-512b-v",
+pub const JSON_EXTRACTION_512B_R1CS: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-512b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/json_extraction_512b.r1cs"
-));
+);
 /// JSON extraction 512b graph
-pub const JSON_EXTRACTION_512B_GRAPH: &[u8] = include_bytes!(concat!(
-  "../../proofs/web_proof_circuits/circom-artifacts-512b-v",
+pub const JSON_EXTRACTION_512B_GRAPH: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-512b-v",
   env!("WEB_PROVER_CIRCUITS_VERSION"),
   "/json_extraction_512b.bin"
-));
+);
+
+const PLAINTEXT_AUTHENTICATION_256B_R1CS: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-256b-v",
+  env!("WEB_PROVER_CIRCUITS_VERSION"),
+  "/plaintext_authentication_256b.r1cs"
+);
+const PLAINTEXT_AUTHENTICATION_256B_GRAPH: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-256b-v",
+  env!("WEB_PROVER_CIRCUITS_VERSION"),
+  "/plaintext_authentication_256b.bin"
+);
+// Circuit 1
+const HTTP_VERIFICATION_256B_R1CS: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-256b-v",
+  env!("WEB_PROVER_CIRCUITS_VERSION"),
+  "/http_verification_256b.r1cs"
+);
+const HTTP_VERIFICATION_256B_GRAPH: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-256b-v",
+  env!("WEB_PROVER_CIRCUITS_VERSION"),
+  "/http_verification_256b.bin"
+);
+// Circuit 2
+const JSON_EXTRACTION_256B_R1CS: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-256b-v",
+  env!("WEB_PROVER_CIRCUITS_VERSION"),
+  "/json_extraction_256b.r1cs"
+);
+const JSON_EXTRACTION_256B_GRAPH: &str = concat!(
+  "proofs/web_proof_circuits/circom-artifacts-256b-v",
+  env!("WEB_PROVER_CIRCUITS_VERSION"),
+  "/json_extraction_256b.bin"
+);
 
 /// WASM witness generator type
 #[allow(dead_code)]
@@ -97,6 +143,12 @@ fn wasm_witness_generator_type_512b() -> [WitnessGeneratorType; 3] {
   ]
 }
 
+fn load_bytes(path: &str) -> Result<Vec<u8>, std::io::Error> {
+  let workspace_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..");
+  let artifact_path = workspace_path.join(path);
+  fs::read(artifact_path)
+}
+
 /// Constructs setup data
 ///
 /// # Arguments
@@ -104,10 +156,15 @@ fn wasm_witness_generator_type_512b() -> [WitnessGeneratorType; 3] {
 /// * `CIRCUIT_SIZE` - A constant representing the circuit size.
 pub fn construct_setup_data<const CIRCUIT_SIZE: usize>() -> Result<UninitializedSetup, ProofError> {
   let r1cs_types = match CIRCUIT_SIZE {
+    CIRCUIT_SIZE_256 => vec![
+      R1CSType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_256B_R1CS)?),
+      R1CSType::Raw(load_bytes(HTTP_VERIFICATION_256B_R1CS)?),
+      R1CSType::Raw(load_bytes(JSON_EXTRACTION_256B_R1CS)?),
+    ],
     CIRCUIT_SIZE_512 => vec![
-      R1CSType::Raw(PLAINTEXT_AUTHENTICATION_512B_R1CS.to_vec()),
-      R1CSType::Raw(HTTP_VERIFICATION_512B_R1CS.to_vec()),
-      R1CSType::Raw(JSON_EXTRACTION_512B_R1CS.to_vec()),
+      R1CSType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_512B_R1CS)?),
+      R1CSType::Raw(load_bytes(HTTP_VERIFICATION_512B_R1CS)?),
+      R1CSType::Raw(load_bytes(JSON_EXTRACTION_512B_R1CS)?),
     ],
     _ => return Err(ProofError::InvalidCircuitSize),
   };
@@ -115,10 +172,15 @@ pub fn construct_setup_data<const CIRCUIT_SIZE: usize>() -> Result<Uninitialized
   #[cfg(not(target_arch = "wasm32"))]
   {
     let witness_generator_types = match CIRCUIT_SIZE {
+      CIRCUIT_SIZE_256 => vec![
+        WitnessGeneratorType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_256B_GRAPH)?),
+        WitnessGeneratorType::Raw(load_bytes(HTTP_VERIFICATION_256B_GRAPH)?),
+        WitnessGeneratorType::Raw(load_bytes(JSON_EXTRACTION_256B_GRAPH)?),
+      ],
       CIRCUIT_SIZE_512 => vec![
-        WitnessGeneratorType::Raw(PLAINTEXT_AUTHENTICATION_512B_GRAPH.to_vec()),
-        WitnessGeneratorType::Raw(HTTP_VERIFICATION_512B_GRAPH.to_vec()),
-        WitnessGeneratorType::Raw(JSON_EXTRACTION_512B_GRAPH.to_vec()),
+        WitnessGeneratorType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_512B_GRAPH)?),
+        WitnessGeneratorType::Raw(load_bytes(HTTP_VERIFICATION_512B_GRAPH)?),
+        WitnessGeneratorType::Raw(load_bytes(JSON_EXTRACTION_512B_GRAPH)?),
       ],
       _ => return Err(ProofError::InvalidCircuitSize),
     };
@@ -133,5 +195,25 @@ pub fn construct_setup_data<const CIRCUIT_SIZE: usize>() -> Result<Uninitialized
       witness_generator_types: vec![WitnessGeneratorType::Browser; 3],
       max_rom_length: MAX_ROM_LENGTH,
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use crate::{
+    circuits::{construct_setup_data, CIRCUIT_SIZE_512},
+    program::data::UninitializedSetup,
+  };
+
+  #[test]
+  fn test_setup_data_persistence() {
+    let expected_setup = construct_setup_data::<CIRCUIT_SIZE_512>().unwrap();
+    let setup_dir = tempdir::TempDir::new("setup").unwrap().path().to_path_buf();
+    std::fs::create_dir_all(&setup_dir).unwrap();
+    let setup_path = setup_dir.join("setup.bin");
+    expected_setup.to_path(&setup_path).unwrap();
+
+    let actual_setup = UninitializedSetup::from_path(&setup_path).unwrap();
+    assert_eq!(expected_setup, actual_setup);
   }
 }

--- a/proofs/src/circuits.rs
+++ b/proofs/src/circuits.rs
@@ -154,7 +154,8 @@ fn load_bytes(path: &str) -> Result<Vec<u8>, std::io::Error> {
 /// # Arguments
 ///
 /// * `CIRCUIT_SIZE` - A constant representing the circuit size.
-pub fn construct_setup_data<const CIRCUIT_SIZE: usize>() -> Result<UninitializedSetup, ProofError> {
+pub fn construct_setup_data_from_fs<const CIRCUIT_SIZE: usize>(
+) -> Result<UninitializedSetup, ProofError> {
   let r1cs_types = match CIRCUIT_SIZE {
     CIRCUIT_SIZE_256 => vec![
       R1CSType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_256B_R1CS)?),
@@ -169,51 +170,19 @@ pub fn construct_setup_data<const CIRCUIT_SIZE: usize>() -> Result<Uninitialized
     _ => return Err(ProofError::InvalidCircuitSize),
   };
 
-  #[cfg(not(target_arch = "wasm32"))]
-  {
-    let witness_generator_types = match CIRCUIT_SIZE {
-      CIRCUIT_SIZE_256 => vec![
-        WitnessGeneratorType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_256B_GRAPH)?),
-        WitnessGeneratorType::Raw(load_bytes(HTTP_VERIFICATION_256B_GRAPH)?),
-        WitnessGeneratorType::Raw(load_bytes(JSON_EXTRACTION_256B_GRAPH)?),
-      ],
-      CIRCUIT_SIZE_512 => vec![
-        WitnessGeneratorType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_512B_GRAPH)?),
-        WitnessGeneratorType::Raw(load_bytes(HTTP_VERIFICATION_512B_GRAPH)?),
-        WitnessGeneratorType::Raw(load_bytes(JSON_EXTRACTION_512B_GRAPH)?),
-      ],
-      _ => return Err(ProofError::InvalidCircuitSize),
-    };
-
-    Ok(UninitializedSetup { r1cs_types, witness_generator_types, max_rom_length: MAX_ROM_LENGTH })
-  }
-
-  #[cfg(target_arch = "wasm32")]
-  {
-    Ok(UninitializedSetup {
-      r1cs_types,
-      witness_generator_types: vec![WitnessGeneratorType::Browser; 3],
-      max_rom_length: MAX_ROM_LENGTH,
-    })
-  }
-}
-
-#[cfg(test)]
-mod tests {
-  use crate::{
-    circuits::{construct_setup_data, CIRCUIT_SIZE_512},
-    program::data::UninitializedSetup,
+  let witness_generator_types = match CIRCUIT_SIZE {
+    CIRCUIT_SIZE_256 => vec![
+      WitnessGeneratorType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_256B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_bytes(HTTP_VERIFICATION_256B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_bytes(JSON_EXTRACTION_256B_GRAPH)?),
+    ],
+    CIRCUIT_SIZE_512 => vec![
+      WitnessGeneratorType::Raw(load_bytes(PLAINTEXT_AUTHENTICATION_512B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_bytes(HTTP_VERIFICATION_512B_GRAPH)?),
+      WitnessGeneratorType::Raw(load_bytes(JSON_EXTRACTION_512B_GRAPH)?),
+    ],
+    _ => return Err(ProofError::InvalidCircuitSize),
   };
 
-  #[test]
-  fn test_setup_data_persistence() {
-    let expected_setup = construct_setup_data::<CIRCUIT_SIZE_512>().unwrap();
-    let setup_dir = tempdir::TempDir::new("setup").unwrap().path().to_path_buf();
-    std::fs::create_dir_all(&setup_dir).unwrap();
-    let setup_path = setup_dir.join("setup.bin");
-    expected_setup.to_path(&setup_path).unwrap();
-
-    let actual_setup = UninitializedSetup::from_path(&setup_path).unwrap();
-    assert_eq!(expected_setup, actual_setup);
-  }
+  Ok(UninitializedSetup { r1cs_types, witness_generator_types, max_rom_length: MAX_ROM_LENGTH })
 }

--- a/proofs/src/program/data.rs
+++ b/proofs/src/program/data.rs
@@ -9,7 +9,7 @@
 
 use std::{
   fs::{self, File},
-  io::{BufReader, Read, Write},
+  io::Write,
   sync::Arc,
 };
 
@@ -92,6 +92,7 @@ pub struct UninitializedSetup {
 }
 
 impl UninitializedSetup {
+  /// Creates an `UninitializedSetup` from bytes representing `R1CSType:Raw`
   pub fn from_raw_r1cs_types_with_browser_witness(r1cs_types: Vec<Vec<u8>>) -> Self {
     let r1cs_types: Vec<_> = r1cs_types.iter().map(|r1cs| R1CSType::Raw(r1cs.clone())).collect();
     let witness_generator_types: Vec<_> = vec![WitnessGeneratorType::Browser; r1cs_types.len()];
@@ -103,6 +104,8 @@ impl UninitializedSetup {
     }
   }
 
+  /// Creates an `UninitializedSetup` from bytes representing `R1CSType:Raw` and
+  /// `WitnessGeneratorType::Raw`
   pub fn from_raw_parts(r1cs_types: Vec<Vec<u8>>, witness_generator_types: Vec<Vec<u8>>) -> Self {
     let r1cs_types = r1cs_types.iter().map(|r1cs| R1CSType::Raw(r1cs.clone())).collect();
     let witness_generator_types =

--- a/proofs/src/program/data.rs
+++ b/proofs/src/program/data.rs
@@ -17,7 +17,7 @@ use client_side_prover::{fast_serde::FastSerde, supernova::get_circuit_shapes};
 use serde_json::json;
 
 use super::*;
-use crate::setup::ProvingParams;
+use crate::{circuits::MAX_ROM_LENGTH, setup::ProvingParams};
 
 /// Fold input for any circuit containing signals name and vector of values. Inputs are distributed
 /// evenly across folds after the ROM is finalised by the prover.
@@ -92,22 +92,11 @@ pub struct UninitializedSetup {
 }
 
 impl UninitializedSetup {
-  pub fn from_bytes(buf: &[u8]) -> Result<Self, ProofError> { Ok(bincode::deserialize(buf)?) }
-
-  pub fn to_bytes(&self) -> Result<Vec<u8>, ProofError> { Ok(bincode::serialize(self)?) }
-
-  pub fn from_path(path: &PathBuf) -> Result<Self, ProofError> {
-    let mut buf_reader = BufReader::new(File::open(path)?);
-    let mut buf = Vec::new();
-    buf_reader.read_to_end(&mut buf)?;
-    Self::from_bytes(&buf)
-  }
-
-  pub fn to_path(&self, path: &PathBuf) -> Result<(), ProofError> {
-    let mut file = File::create(path)?;
-    let bytes = self.to_bytes()?;
-    file.write_all(&bytes)?;
-    Ok(())
+  pub fn from_raw_parts(r1cs_types: Vec<Vec<u8>>, witness_generator_types: Vec<Vec<u8>>) -> Self {
+    let r1cs_types = r1cs_types.iter().map(|r1cs| R1CSType::Raw(r1cs.clone())).collect();
+    let witness_generator_types =
+      witness_generator_types.iter().map(|wgt| WitnessGeneratorType::Raw(wgt.clone())).collect();
+    Self { r1cs_types, witness_generator_types, max_rom_length: MAX_ROM_LENGTH }
   }
 }
 

--- a/proofs/src/program/data.rs
+++ b/proofs/src/program/data.rs
@@ -9,7 +9,7 @@
 
 use std::{
   fs::{self, File},
-  io::Write,
+  io::{BufReader, Read, Write},
   sync::Arc,
 };
 
@@ -75,7 +75,7 @@ pub enum WitnessGeneratorType {
   /// Path to the witness generator
   Path(PathBuf),
   /// Raw bytes of the witness generator
-  #[serde(skip)]
+  // #[serde(skip)] // TODO: Breaks serialization of UninitializedSetup, why did we skip here?
   Raw(Vec<u8>), // TODO: Would prefer to not alloc here, but i got lifetime hell lol
 }
 
@@ -89,6 +89,26 @@ pub struct UninitializedSetup {
   pub witness_generator_types: Vec<WitnessGeneratorType>,
   /// NIVC max ROM length
   pub max_rom_length:          usize,
+}
+
+impl UninitializedSetup {
+  pub fn from_bytes(buf: &[u8]) -> Result<Self, ProofError> { Ok(bincode::deserialize(buf)?) }
+
+  pub fn to_bytes(&self) -> Result<Vec<u8>, ProofError> { Ok(bincode::serialize(self)?) }
+
+  pub fn from_path(path: &PathBuf) -> Result<Self, ProofError> {
+    let mut buf_reader = BufReader::new(File::open(path)?);
+    let mut buf = Vec::new();
+    buf_reader.read_to_end(&mut buf)?;
+    Self::from_bytes(&buf)
+  }
+
+  pub fn to_path(&self, path: &PathBuf) -> Result<(), ProofError> {
+    let mut file = File::create(path)?;
+    let bytes = self.to_bytes()?;
+    file.write_all(&bytes)?;
+    Ok(())
+  }
 }
 
 /// Initialized Circuit Setup data, in this configuration the R1CS objects have been

--- a/proofs/src/program/data.rs
+++ b/proofs/src/program/data.rs
@@ -92,6 +92,17 @@ pub struct UninitializedSetup {
 }
 
 impl UninitializedSetup {
+  pub fn from_raw_r1cs_types_with_browser_witness(r1cs_types: Vec<Vec<u8>>) -> Self {
+    let r1cs_types: Vec<_> = r1cs_types.iter().map(|r1cs| R1CSType::Raw(r1cs.clone())).collect();
+    let witness_generator_types: Vec<_> = vec![WitnessGeneratorType::Browser; r1cs_types.len()];
+    Self {
+      r1cs_types,
+      witness_generator_types,
+      // TODO: Should this be hardcoded or a parameter?
+      max_rom_length: MAX_ROM_LENGTH,
+    }
+  }
+
   pub fn from_raw_parts(r1cs_types: Vec<Vec<u8>>, witness_generator_types: Vec<Vec<u8>>) -> Self {
     let r1cs_types = r1cs_types.iter().map(|r1cs| R1CSType::Raw(r1cs.clone())).collect();
     let witness_generator_types =
@@ -331,7 +342,7 @@ impl SetupParams<Offline> {
     let proving_params = ProvingParams::from_bytes(&self.public_params).unwrap();
 
     info!("init setup");
-    let initialized_setup = initialize_setup_data(&self.setup_data).unwrap();
+    let initialized_setup = initialize_setup_data(&self.setup_data)?;
 
     let circuits = initialize_circuit_list(&initialized_setup);
     let memory = Memory { circuits, rom: vec![0; self.setup_data.max_rom_length] };

--- a/proofs/src/program/data.rs
+++ b/proofs/src/program/data.rs
@@ -96,7 +96,12 @@ impl UninitializedSetup {
     let r1cs_types = r1cs_types.iter().map(|r1cs| R1CSType::Raw(r1cs.clone())).collect();
     let witness_generator_types =
       witness_generator_types.iter().map(|wgt| WitnessGeneratorType::Raw(wgt.clone())).collect();
-    Self { r1cs_types, witness_generator_types, max_rom_length: MAX_ROM_LENGTH }
+    Self {
+      r1cs_types,
+      witness_generator_types,
+      // TODO: Should this be hardcoded or a parameter?
+      max_rom_length: MAX_ROM_LENGTH,
+    }
   }
 }
 

--- a/proofs/src/tests/mod.rs
+++ b/proofs/src/tests/mod.rs
@@ -18,10 +18,13 @@ use inputs::{
 use web_proof_circuits_witness_generator::polynomial_digest;
 
 use super::*;
-use crate::program::{
-  data::{CircuitData, NotExpanded, ProofParams, SetupParams, UninitializedSetup},
-  initialize_setup_data,
-  manifest::{InitialNIVCInputs, NIVCRom, NivcCircuitInputs, OrigoManifest},
+use crate::{
+  circuits::load_artifact_bytes,
+  program::{
+    data::{CircuitData, NotExpanded, ProofParams, SetupParams, UninitializedSetup},
+    initialize_setup_data,
+    manifest::{InitialNIVCInputs, NIVCRom, NivcCircuitInputs, OrigoManifest},
+  },
 };
 
 pub(crate) mod inputs;
@@ -224,15 +227,15 @@ async fn test_end_to_end_proofs_post() {
 
   let setup_data = UninitializedSetup {
     r1cs_types:              vec![
-      R1CSType::Raw(PLAINTEXT_AUTHENTICATION_512B_R1CS.to_vec()),
-      R1CSType::Raw(HTTP_VERIFICATION_512B_R1CS.to_vec()),
-      R1CSType::Raw(JSON_EXTRACTION_512B_R1CS.to_vec()),
+      R1CSType::Raw(load_artifact_bytes(PLAINTEXT_AUTHENTICATION_512B_R1CS).unwrap()),
+      R1CSType::Raw(load_artifact_bytes(HTTP_VERIFICATION_512B_R1CS).unwrap()),
+      R1CSType::Raw(load_artifact_bytes(JSON_EXTRACTION_512B_R1CS).unwrap()),
     ],
     witness_generator_types: // wasm_witness_generator_type_512b().to_vec(),
     vec![
-      WitnessGeneratorType::Raw(PLAINTEXT_AUTHENTICATION_512B_GRAPH.to_vec()),
-      WitnessGeneratorType::Raw(HTTP_VERIFICATION_512B_GRAPH.to_vec()),
-      WitnessGeneratorType::Raw(JSON_EXTRACTION_512B_GRAPH.to_vec()),
+      WitnessGeneratorType::Raw(load_artifact_bytes(PLAINTEXT_AUTHENTICATION_512B_GRAPH).unwrap()),
+      WitnessGeneratorType::Raw(load_artifact_bytes(HTTP_VERIFICATION_512B_GRAPH).unwrap()),
+      WitnessGeneratorType::Raw(load_artifact_bytes(JSON_EXTRACTION_512B_GRAPH).unwrap()),
     ],
     max_rom_length:          MAX_ROM_LENGTH,
   };


### PR DESCRIPTION
- Fixes: #309 
- Added WASM and iOS-facing APIs for loading `UninitializedSetup` from raw bytes on the client side. iOS API is a documented but untested draft - I'd appreciate some pointers on what to do here.
- Removed inlined circuit data in the native build and replaced with a FS-based loader
- Required reviews: 2