### PR TITLE
chore: bring back check-llvm in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ check-llvm:
 		exit 1; \
 	fi
 
-wasm: artifacts
+wasm: check-llvm artifacts
 	@# NOTE: This build depends on RUSTFLAGS in the client_wasm/.cargo/config.toml
 	-cargo install wasm-pack
 	-cd client_wasm/demo/static && rm -f build && ln -s ../../../proofs/web_proof_circuits build && cd ../../..


### PR DESCRIPTION
sorry, removed by accident while struggling with my local llvm install. removed it and forgot to bring it back. 