### PR TITLE
check ciphertext digest in notary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3919,7 +3919,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-subscriber",
- "web-proof-circuits-witness-generator",
  "ws_stream_tungstenite 0.13.0 (git+https://github.com/pluto/ws_stream_tungstenite.git?branch=latest)",
 ]
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -171,8 +171,9 @@ pub async fn prover_inner_proxy(config: config::Config) -> Result<Proof, errors:
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct OrigoProof {
-  pub proof: FoldingProof<Vec<u8>, String>,
-  pub rom:   NIVCRom,
+  pub proof:             FoldingProof<Vec<u8>, String>,
+  pub ciphertext_digest: [u8; 32],
+  pub rom:               NIVCRom,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/client/src/proof.rs
+++ b/client/src/proof.rs
@@ -62,5 +62,9 @@ pub async fn construct_program_data_and_proof<const CIRCUIT_SIZE: usize>(
 
   debug!("starting recursive proving");
   let proof = setup_params.generate_proof(&proof_params, &instance_params).await?;
-  Ok(OrigoProof { proof, rom: NIVCRom { circuit_data, rom } })
+  Ok(OrigoProof {
+    proof,
+    ciphertext_digest: initial_nivc_input[0].to_bytes(),
+    rom: NIVCRom { circuit_data, rom },
+  })
 }

--- a/notary/Cargo.toml
+++ b/notary/Cargo.toml
@@ -59,7 +59,6 @@ tls-client2={ workspace=true }
 
 caratls_ekm_server                          ={ workspace=true }
 caratls_ekm_google_confidential_space_server={ workspace=true }
-web-proof-circuits-witness-generator        ={ workspace=true }
 
 [dev-dependencies]
 tower="0.4.13"

--- a/notary/src/main.rs
+++ b/notary/src/main.rs
@@ -8,14 +8,14 @@ use std::{
 use axum::{
   extract::{Path, Request, State},
   http::StatusCode,
-  response::{IntoResponse, Response},
+  response::IntoResponse,
   routing::{get, post},
   Router,
 };
 use errors::NotaryServerError;
 use hyper::{body::Incoming, server::conn::http1};
 use hyper_util::rt::TokioIo;
-use k256::ecdsa::{SigningKey as Secp256k1SigningKey, VerifyingKey};
+use k256::ecdsa::SigningKey as Secp256k1SigningKey;
 use p256::{ecdsa::SigningKey, elliptic_curve::rand_core, pkcs8::DecodePrivateKey};
 use rustls::{
   pki_types::{CertificateDer, PrivateKeyDer},

--- a/notary/src/tls_parser.rs
+++ b/notary/src/tls_parser.rs
@@ -1,8 +1,6 @@
 use std::io::Cursor;
 
-use k256::elliptic_curve::Field;
 use nom::{bytes::streaming::take, IResult};
-use proofs::{circuits::CIRCUIT_SIZE_512, F, G1};
 use tls_client2::{
   hash_hs::HandshakeHashBuffer,
   internal::msgs::hsjoiner::HandshakeJoiner,
@@ -25,7 +23,6 @@ use tls_parser::{
   TlsMessageHandshake, TlsServerHelloContents,
 };
 use tracing::{debug, error, info, trace};
-use web_proof_circuits_witness_generator::{data_hasher, ByteOrPad};
 
 use crate::errors::ProxyError;
 
@@ -333,46 +330,6 @@ impl Transcript<Parsed> {
     Err(ProxyError::TlsHandshakeVerify(String::from("unable to parse verify data")))
   }
 
-  /// Given chunks of possible request or response data, compute
-  /// the valid subsequences and hash them.
-  ///
-  /// Example:
-  /// Given as input three chunks of bytes [1,2,3]
-  ///
-  /// Output:
-  /// [H([1]), H([1,2]), H([1,2,3]), H([2]), H([2,3]), H([3])]
-  fn get_permutations(input: &[Vec<u8>]) -> Vec<F<G1>> {
-    let mut result = Vec::new();
-
-    fn get_hashes(bytes: Vec<u8>) -> Vec<F<G1>> {
-      vec![CIRCUIT_SIZE_512]
-        .into_iter()
-        .filter(|&size| bytes.len() <= size)
-        .map(|size| {
-          data_hasher(
-            &ByteOrPad::from_bytes_with_padding(&bytes, size - bytes.len()),
-            F::<G1>::ZERO,
-          )
-        })
-        .collect()
-    }
-
-    for i in 0..input.len() {
-      let mut current = Vec::new();
-      result.extend(get_hashes(input[i].clone()));
-      current.extend(&input[i]);
-
-      for item in input[i + 1..].iter() {
-        let mut combined = current.clone();
-        combined.extend(item);
-        result.extend(get_hashes(combined.clone()));
-      }
-    }
-
-    result.dedup();
-    result
-  }
-
   /// Retrieve possible valid hashes of ciphertext. Unfortunately using encrypted
   /// TLS 1.3 data as input, there is not a deterministic way to extract the
   /// request and response data.  There can be a variable number of either request
@@ -384,7 +341,7 @@ impl Transcript<Parsed> {
   ///
   /// To skip redundant verification in the future, we could accept a possible target hash
   /// from the client and check if it is in the set of valid hashes.
-  pub fn get_ciphertext_hashes(&self) -> (Vec<F<G1>>, Vec<F<G1>>, Vec<Vec<u8>>, Vec<Vec<u8>>) {
+  pub fn get_ciphertext_hashes(&self) -> (Vec<Vec<u8>>, Vec<Vec<u8>>) {
     // State machine for extracting request response
     // Transcript Structure:
     // - Encrypted 1: server sends back verify data
@@ -394,6 +351,7 @@ impl Transcript<Parsed> {
     // - Encrypted j..k: server sends back real response
     // - Encrypted k: server sends close notify => drop message
     //
+    #[derive(Debug)]
     enum State {
       SeekingRequest,
       ParsingRequest,
@@ -404,8 +362,6 @@ impl Transcript<Parsed> {
       m: &ParsedMessage,
       bytes: Vec<u8>,
       s: State,
-      idx: usize,
-      last_msg_idx: usize,
       req: &mut Vec<Vec<u8>>,
       resp: &mut Vec<Vec<u8>>,
     ) -> State {
@@ -426,29 +382,25 @@ impl Transcript<Parsed> {
             req.push(trimmed_bytes);
             State::ParsingRequest
           } else {
-            // Case: first message from server after request
             resp.push(trimmed_bytes);
             State::ParsingResponse
           }
         },
-        State::ParsingResponse => {
+        State::ParsingResponse =>
           if matches!(m.direction, Direction::Received) {
-            // Case: receiving message & not the last message. Drop last message, it's close notify.
-            if idx < last_msg_idx {
-              resp.push(trimmed_bytes);
-            }
+            resp.push(trimmed_bytes);
             State::ParsingResponse
           } else {
             panic!("expected only response data");
-          }
-        },
+          },
       }
     }
 
     let mut request_messages: Vec<Vec<u8>> = Vec::new();
     let mut response_messages: Vec<Vec<u8>> = Vec::new();
     let mut current_state = State::SeekingRequest;
-    for (m_idx, m) in self.payload.iter().enumerate() {
+    debug!("Transcript length: {}", self.payload.len());
+    for m in self.payload.iter() {
       match &m.payload {
         WrappedPayload::Encrypted(e) => {
           info!(
@@ -463,8 +415,6 @@ impl Transcript<Parsed> {
             m,
             e.payload.0.clone(),
             current_state,
-            m_idx,
-            self.payload.len() - 1,
             &mut request_messages,
             &mut response_messages,
           );
@@ -482,11 +432,7 @@ impl Transcript<Parsed> {
       };
     }
 
-    // TODO (sambhav): see if can remove this?
-    let request_hashes = Transcript::<Parsed>::get_permutations(&request_messages);
-    let response_hashes = Transcript::<Parsed>::get_permutations(&response_messages);
-
-    (request_hashes, response_hashes, request_messages, response_messages)
+    (request_messages, response_messages)
   }
 }
 

--- a/proofs/src/program/manifest.rs
+++ b/proofs/src/program/manifest.rs
@@ -705,6 +705,30 @@ fn build_json_extraction_circuit_inputs<const CIRCUIT_SIZE: usize>(
   Ok(value_digest - data_digest)
 }
 
+pub fn compute_ciphertext_digest<const CIRCUIT_SIZE: usize>(
+  request_ciphertext: &[Vec<u8>],
+  response_ciphertext: &[Vec<u8>],
+) -> F<G1> {
+  let padded_request_ciphertext = request_ciphertext
+    .iter()
+    .map(|c| ByteOrPad::pad_to_nearest_multiple(c, CIRCUIT_SIZE))
+    .collect::<Vec<Vec<ByteOrPad>>>();
+  let padded_response_ciphertext = response_ciphertext
+    .iter()
+    .map(|c| ByteOrPad::pad_to_nearest_multiple(c, CIRCUIT_SIZE))
+    .collect::<Vec<Vec<ByteOrPad>>>();
+
+  let mut ciphertext_digest = F::<G1>::ZERO;
+  padded_request_ciphertext
+    .iter()
+    .for_each(|c| ciphertext_digest = data_hasher(c, ciphertext_digest));
+  padded_response_ciphertext
+    .iter()
+    .for_each(|c| ciphertext_digest = data_hasher(c, ciphertext_digest));
+
+  ciphertext_digest
+}
+
 impl Manifest {
   pub fn initial_inputs<const MAX_STACK_HEIGHT: usize, const CIRCUIT_SIZE: usize>(
     &self,
@@ -712,22 +736,8 @@ impl Manifest {
     request_ciphertext: &[Vec<u8>],
     response_ciphertext: &[Vec<u8>],
   ) -> Result<InitialNIVCInputs, ProofError> {
-    let padded_request_ciphertext = request_ciphertext
-      .iter()
-      .map(|c| ByteOrPad::pad_to_nearest_multiple(c, CIRCUIT_SIZE))
-      .collect::<Vec<Vec<ByteOrPad>>>();
-    let padded_response_ciphertext = response_ciphertext
-      .iter()
-      .map(|c| ByteOrPad::pad_to_nearest_multiple(c, CIRCUIT_SIZE))
-      .collect::<Vec<Vec<ByteOrPad>>>();
-
-    let mut ciphertext_digest = F::<G1>::ZERO;
-    padded_request_ciphertext
-      .iter()
-      .for_each(|c| ciphertext_digest = data_hasher(c, ciphertext_digest));
-    padded_response_ciphertext
-      .iter()
-      .for_each(|c| ciphertext_digest = data_hasher(c, ciphertext_digest));
+    let ciphertext_digest =
+      compute_ciphertext_digest::<CIRCUIT_SIZE>(request_ciphertext, response_ciphertext);
 
     // TODO: This assumes the start line format here as well.
     // digest the start line for request/response using the ciphertext_digest as a random input


### PR DESCRIPTION
- adds permutation logic to check correct ciphertext response packets in notary
- unblocks all examples in extension (verification successful)