### PR TITLE
chore: bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-tungstenite 0.25.1",
  "base64 0.22.1",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "client_ios"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cargo_metadata",
  "client",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "client_wasm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "cargo_metadata",
  "client",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "notary"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -4609,7 +4609,7 @@ dependencies = [
 
 [[package]]
 name = "proofs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bellpepper-core",
  "bincode",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="client"
-version="0.4.0"
+version="0.5.0"
 edition="2021"
 build  ="build.rs"
 publish=false

--- a/client_ios/Cargo.toml
+++ b/client_ios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="client_ios"
-version="0.4.0"
+version="0.5.0"
 edition="2021"
 build  ="build.rs"
 publish=false

--- a/client_wasm/Cargo.toml
+++ b/client_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="client_wasm"
-version="0.4.0"
+version="0.5.0"
 edition="2021"
 build  ="build.rs"
 publish=false

--- a/notary/Cargo.toml
+++ b/notary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="notary"
-version="0.4.0"
+version="0.5.0"
 edition="2021"
 build  ="build.rs"
 

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="proofs"
-version="0.4.0"
+version="0.5.0"
 edition="2021"
 publish=false
 build  ="build.rs"


### PR DESCRIPTION
This will make a new release with logic from #477 and other recent changes. 