### PR TITLE
feat:  Finish e2e working tee proof

### DIFF
--- a/client/src/origo_wasm32.rs
+++ b/client/src/origo_wasm32.rs
@@ -21,22 +21,27 @@ use tokio_util::{
 };
 use tracing::debug;
 use wasm_bindgen_futures::{spawn_local, JsFuture};
+use wasm_bindgen::prelude::*;
 use web_sys::window;
 use ws_stream_wasm::WsMeta;
+use js_sys::{Function, Promise};
 
 use crate::{
   config, config::NotaryMode, errors, errors::ClientErrors, origo::OrigoSecrets,
   tls_client_async2::bind_client, TeeProof,
 };
 
+
 async fn sleep(ms: u64) {
-  let promise = js_sys::Promise::new(&mut |resolve, _| {
-    window()
-      .unwrap()
-      .set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, ms as i32)
-      .unwrap();
-  });
-  JsFuture::from(promise).await.unwrap();
+    #[wasm_bindgen]
+    extern "C" {
+        #[wasm_bindgen(js_namespace = globalThis)]
+        fn setTimeout(callback: &Function, timeout: i32);
+    }
+    let promise = Promise::new(&mut |resolve, _| {
+        setTimeout(&resolve, ms as i32);
+    });
+    JsFuture::from(promise).await.unwrap();
 }
 
 pub(crate) async fn proxy(

--- a/client/src/origo_wasm32.rs
+++ b/client/src/origo_wasm32.rs
@@ -14,34 +14,33 @@ use caratls_ekm_client::TeeTlsConnector;
 use caratls_ekm_google_confidential_space_client::GoogleConfidentialSpaceTokenVerifier;
 use futures::{channel::oneshot, AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt};
 use hyper::StatusCode;
+use js_sys::{Function, Promise};
 use tls_client2::origo::OrigoConnection;
 use tokio_util::{
   codec::{Framed, LengthDelimitedCodec},
   compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt},
 };
 use tracing::debug;
-use wasm_bindgen_futures::{spawn_local, JsFuture};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::{spawn_local, JsFuture};
 use web_sys::window;
 use ws_stream_wasm::WsMeta;
-use js_sys::{Function, Promise};
 
 use crate::{
   config, config::NotaryMode, errors, errors::ClientErrors, origo::OrigoSecrets,
   tls_client_async2::bind_client, TeeProof,
 };
 
-
 async fn sleep(ms: u64) {
-    #[wasm_bindgen]
-    extern "C" {
-        #[wasm_bindgen(js_namespace = globalThis)]
-        fn setTimeout(callback: &Function, timeout: i32);
-    }
-    let promise = Promise::new(&mut |resolve, _| {
-        setTimeout(&resolve, ms as i32);
-    });
-    JsFuture::from(promise).await.unwrap();
+  #[wasm_bindgen]
+  extern "C" {
+    #[wasm_bindgen(js_namespace = globalThis)]
+    fn setTimeout(callback: &Function, timeout: i32);
+  }
+  let promise = Promise::new(&mut |resolve, _| {
+    setTimeout(&resolve, ms as i32);
+  });
+  JsFuture::from(promise).await.unwrap();
 }
 
 pub(crate) async fn proxy(

--- a/client/src/tls_client_async2/mod.rs
+++ b/client/src/tls_client_async2/mod.rs
@@ -11,9 +11,9 @@
 
 mod conn;
 use std::{
+  io::Read,
   pin::Pin,
   task::{Context, Poll},
-  io::Read,
 };
 
 use bytes::{Buf, Bytes};
@@ -158,7 +158,7 @@ pub fn bind_client<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
               // it back on the buffer because we recreate the reader below.
               let mut reader = rx_tls_buf[..received].reader();
               let mut bytes_buf = [0u8; 1];
-              reader.read_exact(&mut bytes_buf)?;  
+              reader.read_exact(&mut bytes_buf)?;
               let is_terminate_byte = received == 1 && bytes_buf.get(0).cloned() == Some(255);
 
               let mut reader = rx_tls_buf[..received].reader();

--- a/client/src/tls_client_async2/mod.rs
+++ b/client/src/tls_client_async2/mod.rs
@@ -13,6 +13,7 @@ mod conn;
 use std::{
   pin::Pin,
   task::{Context, Poll},
+  io::Read,
 };
 
 use bytes::{Buf, Bytes};
@@ -152,6 +153,14 @@ pub fn bind_client<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
               // Loop until we've processed all the data we received in this read.
               // Note that we must make one iteration even if `received == 0`.
               let mut processed = 0;
+
+              // Check for a special termination character. We do not need to place
+              // it back on the buffer because we recreate the reader below.
+              let mut reader = rx_tls_buf[..received].reader();
+              let mut bytes_buf = [0u8; 1];
+              reader.read_exact(&mut bytes_buf)?;  
+              let is_terminate_byte = received == 1 && bytes_buf.get(0).cloned() == Some(255);
+
               let mut reader = rx_tls_buf[..received].reader();
               loop {
                   processed += client.read_tls(&mut reader)?;
@@ -165,19 +174,9 @@ pub fn bind_client<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
 
               trace!("processed {} tls bytes from server", processed);
 
-              // By convention if `AsyncRead::read` returns 0, it means EOF, i.e. the peer
-              // has closed the socket.  Also close on received_close_notify, else we hang.
-
-              // if client.received_close_notify() {
-                  // break 'conn;
-                  // client_closed = true;
-                  // rx_tls_fut = Fuse::terminated();
-              // }
-
-              // TODO change from tracy:
-              if received == 0 || client.received_close_notify() {
-              // if received == 0  {
-                  debug!("server closed connection");
+              // Check: EOF or server properly closed or proxy closed
+              if received == 0 || client.received_close_notify() || is_terminate_byte {
+                  trace!("connection closed: eof or server closed or proxy terminate");
                   server_closed = true;
                   client.server_closed().await?;
 
@@ -185,6 +184,7 @@ pub fn bind_client<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
                   rx_tls_fut = Fuse::terminated();
               } else {
                   // Reset the read future so next iteration we can read again.
+                  trace!("ready to read more data....");
                   rx_tls_fut = server_rx.read(&mut rx_tls_buf).fuse();
               }
           }

--- a/client/src/tls_client_async2/mod.rs
+++ b/client/src/tls_client_async2/mod.rs
@@ -159,7 +159,7 @@ pub fn bind_client<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
               let mut reader = rx_tls_buf[..received].reader();
               let mut bytes_buf = [0u8; 1];
               reader.read_exact(&mut bytes_buf)?;
-              let is_terminate_byte = received == 1 && bytes_buf.get(0).cloned() == Some(255);
+              let is_terminate_byte = received == 1 && bytes_buf.first().cloned() == Some(255);
 
               let mut reader = rx_tls_buf[..received].reader();
               loop {

--- a/notary/src/errors.rs
+++ b/notary/src/errors.rs
@@ -91,9 +91,6 @@ pub enum NotaryServerError {
   #[error(transparent)]
   ProofError(#[from] ProofError),
 
-  #[error("Missing application-level data messages. Direction={0}, expected={1}, received={2}")]
-  MissingAppDataMessages(Direction, usize, usize),
-
   // TODO: Update to contain feedback
   #[error("Manifest-request mismatch")]
   ManifestRequestMismatch,

--- a/notary/src/proxy.rs
+++ b/notary/src/proxy.rs
@@ -64,11 +64,18 @@ async fn from_reqwest_response(response: Response) -> ManifestResponse {
     .iter()
     .map(|(k, v)| (capitalize_header(k.as_ref()), v.to_str().unwrap_or("").to_string()))
     .collect();
+
   let body: HashMap<String, String> = response.json().await.unwrap_or_default();
   // TODO: How to handle JsonKey::Num?
   // TODO Use plain JSON in Manifest etc., and convert to JsonKey as needed
-  let body: Vec<JsonKey> = body.keys().map(|k| JsonKey::String(k.to_string())).collect();
-  ManifestResponse { status, version, message, headers, body: ResponseBody { json: body } }
+  let json_keys: Vec<JsonKey> = body.keys().map(|k| JsonKey::String(k.to_string())).collect();
+  ManifestResponse {
+    status,
+    version,
+    message,
+    headers,
+    body: ResponseBody { json: json_keys, json_actual: None },
+  }
 }
 
 fn from_reqwest_request(request: &Request) -> ManifestRequest {

--- a/notary/src/tee.rs
+++ b/notary/src/tee.rs
@@ -275,8 +275,10 @@ fn validate_notarization_legal(
   if !manifest.request.is_subset_of(&request) {
     return Err(NotaryServerError::ManifestRequestMismatch);
   }
+
   if !manifest.response.is_subset_of(&response) {
     return Err(NotaryServerError::ManifestResponseMismatch);
   }
+
   Ok(())
 }

--- a/notary/src/tee.rs
+++ b/notary/src/tee.rs
@@ -24,7 +24,7 @@ use serde::Deserialize;
 use tls_client2::tls_core::msgs::message::MessagePayload;
 use tokio::{
   io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-  time::{timeout, Duration}
+  time::{timeout, Duration},
 };
 use tokio_stream::StreamExt;
 use tokio_util::{

--- a/notary/src/tee.rs
+++ b/notary/src/tee.rs
@@ -280,13 +280,3 @@ fn validate_notarization_legal(
   }
   Ok(())
 }
-
-fn get_app_data(payload: &WrappedPayload) -> Option<Vec<u8>> {
-  match payload {
-    WrappedPayload::Decrypted(decrypted) => match &decrypted.payload {
-      MessagePayload::ApplicationData(app_data) => Some(app_data.clone().0),
-      _ => None,
-    },
-    _ => None,
-  }
-}

--- a/proofs/src/program/http.rs
+++ b/proofs/src/program/http.rs
@@ -269,7 +269,7 @@ impl ManifestResponse {
         self.body.json,
         other.body.json_actual.as_ref().unwrap()
       );
-      return false
+      return false;
     }
 
     // All checks passed
@@ -522,7 +522,6 @@ pub(crate) mod tests {
 
   #[test]
   fn test_matches_other_response() {
-    
     let sourced_response = create_response!(
         headers: HashMap::from([("Content-Type".to_string(), "application/json".to_string())]),
         body: ResponseBody {

--- a/proofs/src/tests/inputs.rs
+++ b/proofs/src/tests/inputs.rs
@@ -686,11 +686,12 @@ pub(crate) fn complex_manifest() -> Manifest {
         ("Server".to_string(), "nginx/1.18.0".to_string()),
       ]),
       body:    ResponseBody {
-        json: vec![
+        json:        vec![
           JsonKey::String(String::from("data")),
           JsonKey::String(String::from("orderDetails")),
           JsonKey::String(String::from("orderId")),
         ],
+        json_actual: None,
       },
     },
   }


### PR DESCRIPTION
PR includes:
- Fix a synchronization bug that was causing hangs in several cases
- Update the TLS parsing to correctly extract data
- Update TLS Parsing to support HTTP req/response
- Fix manifest JSON matching to support full key and body. 


**Background on the synchronization bug**
The TEE infra is reusing the underlying proxy networking stack. At the moment this requires a bit of a dance to secure the connection via EKM (caratls) and then complete the movement of data to the target web server and then subsequent data transport.

It's all overcomplicated, but for the moment it's best to make it work. This PR fixes some adhoc synchronization logic we introduced. We should really do this in a better way, but right now it needs fixed. 

I created a follow up issue to add a framing protocol above this (if we decide to keep this networking stack): https://github.com/pluto/web-prover/issues/470


Closes #496, #497