### PR TITLE
chore: pin nightly and migrate to 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3320,10 +3320,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -7199,24 +7200,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -7225,21 +7226,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7247,9 +7249,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7272,9 +7274,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -7349,9 +7354,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 name   ="webprover"
-edition="2021"
+edition="2024"
 
 [workspace]
 members=["client", "client_ios", "client_wasm", "notary", "proofs", "web-prover-core"]

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,13 @@ ios: artifacts
 	-cargo install cbindgen
 	# Build simulator
 	rustup target add aarch64-apple-ios-sim --toolchain nightly
-	RUSTFLAGS="-C panic=unwind" cargo  build -p client_ios --release --target aarch64-apple-ios-sim # builds target/aarch64-apple-ios-sim/release/libclient_ios.a
+	RUSTFLAGS="-C panic=unwind" cargo build -p client_ios --release --target aarch64-apple-ios-sim # builds target/aarch64-apple-ios-sim/release/libclient_ios.a
 	mkdir -p target/sim/headers
 	~/.cargo/bin/cbindgen --lang c --crate client_ios --output target/sim/headers/Prover.h
 	mv target/aarch64-apple-ios-sim/release/libclient_ios.a target/sim/libProver.a
 	# Build device
 	rustup target add aarch64-apple-ios --toolchain nightly
-	RUSTFLAGS="-C panic=unwind" cargo   build -p client_ios --release --target aarch64-apple-ios # builds target/aarch64-apple-ios/release/libclient_ios.a
+	RUSTFLAGS="-C panic=unwind" cargo build -p client_ios --release --target aarch64-apple-ios # builds target/aarch64-apple-ios/release/libclient_ios.a
 	mkdir -p target/device/headers
 	~/.cargo/bin/cbindgen --lang c --crate client_ios --output target/device/headers/Prover.h
 	mv target/aarch64-apple-ios/release/libclient_ios.a target/device/libProver.a

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name   ="client"
-version="0.6.0"
-edition="2021"
-build  ="build.rs"
-publish=false
+name             ="client"
+version          ="0.6.0"
+build            ="build.rs"
+publish          =false
+edition.workspace=true
 
 [features]
 default=["tee-dummy-token-verifier"]

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use base64::prelude::*;
 use http_body_util::Full;
 use hyper::{
+  Request,
   body::Bytes,
   header::{HeaderName, HeaderValue},
-  Request,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{

--- a/client/src/origo.rs
+++ b/client/src/origo.rs
@@ -2,27 +2,27 @@
 use std::collections::HashMap;
 
 use proofs::{
+  F, G1, G2,
   circuits::construct_setup_data,
   program::{
     data::{Offline, SetupParams},
     manifest::{EncryptionInput, OrigoManifest, TLSEncryption},
   },
-  F, G1, G2,
 };
 use serde::{Deserialize, Serialize};
 use tls_client2::origo::OrigoConnection;
 use tracing::debug;
 use web_proof_circuits_witness_generator::{
-  http::{compute_http_witness, HttpMaskType},
+  http::{HttpMaskType, compute_http_witness},
   json::json_value_digest,
 };
 use web_prover_core::{manifest::Manifest, proof::SignedVerificationReply};
 
 use crate::{
+  OrigoProof,
   config::{self},
   errors::ClientErrors,
   tls::decrypt_tls_ciphertext,
-  OrigoProof,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -242,10 +242,10 @@ mod tests {
   fn test_manifest_serialization() {
     let mut origo_conn = OrigoConnection::new();
     origo_conn.secret_map.insert("Handshake:server_iv".to_string(), vec![1, 2, 3]);
-    let origo_secrets = OrigoSecrets::from_origo_conn(&origo_conn);
+    let origo_secrets = &OrigoSecrets::from_origo_conn(&origo_conn);
 
     let serialized: Vec<u8> = origo_secrets.try_into().unwrap();
-    let deserialized: OrigoSecrets = OrigoSecrets::try_from(&serialized).unwrap();
-    assert_eq!(origo_secrets, deserialized);
+    let deserialized: OrigoSecrets = OrigoSecrets::try_from(serialized.as_ref()).unwrap();
+    assert_eq!(*origo_secrets, deserialized);
   }
 }

--- a/client/src/origo_native.rs
+++ b/client/src/origo_native.rs
@@ -6,10 +6,10 @@ use caratls_ekm_client::TeeTlsConnector;
 #[cfg(feature = "tee-google-confidential-space-token-verifier")]
 use caratls_ekm_google_confidential_space_client::GoogleConfidentialSpaceTokenVerifier;
 use futures::{
-  channel::oneshot, AsyncReadExt, AsyncWriteExt as FuturesWriteExt, SinkExt, StreamExt,
+  AsyncReadExt, AsyncWriteExt as FuturesWriteExt, SinkExt, StreamExt, channel::oneshot,
 };
 use http_body_util::{BodyExt, Full};
-use hyper::{body::Bytes, Request, StatusCode};
+use hyper::{Request, StatusCode, body::Bytes};
 use tls_client2::origo::OrigoConnection;
 use tokio::io::AsyncWriteExt;
 use tokio_util::{
@@ -19,11 +19,11 @@ use tokio_util::{
 use tracing::debug;
 
 use crate::{
+  TeeProof,
   config::{self, Config, NotaryMode},
   errors::ClientErrors,
   origo::OrigoSecrets,
   tls_client_async2::TlsConnection,
-  TeeProof,
 };
 
 // TODO: Can be refactored further with shared logic from origo_wasm32.rs

--- a/client/src/origo_wasm32.rs
+++ b/client/src/origo_wasm32.rs
@@ -12,7 +12,7 @@ use caratls_ekm_client::DummyTokenVerifier;
 use caratls_ekm_client::TeeTlsConnector;
 #[cfg(feature = "tee-google-confidential-space-token-verifier")]
 use caratls_ekm_google_confidential_space_client::GoogleConfidentialSpaceTokenVerifier;
-use futures::{channel::oneshot, AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt};
+use futures::{AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt, channel::oneshot};
 use hyper::StatusCode;
 use js_sys::{Function, Promise};
 use tls_client2::origo::OrigoConnection;
@@ -22,13 +22,13 @@ use tokio_util::{
 };
 use tracing::debug;
 use wasm_bindgen::prelude::*;
-use wasm_bindgen_futures::{spawn_local, JsFuture};
+use wasm_bindgen_futures::{JsFuture, spawn_local};
 use web_sys::window;
 use ws_stream_wasm::WsMeta;
 
 use crate::{
-  config, config::NotaryMode, errors, errors::ClientErrors, origo::OrigoSecrets,
-  tls_client_async2::bind_client, TeeProof,
+  TeeProof, config, config::NotaryMode, errors, errors::ClientErrors, origo::OrigoSecrets,
+  tls_client_async2::bind_client,
 };
 
 async fn sleep(ms: u64) {

--- a/client/src/proof.rs
+++ b/client/src/proof.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use client_side_prover::supernova::PublicParams;
 use proofs::{
+  E1, F, G1, G2,
   program::{
     data::{InitializedSetup, InstanceParams, NotExpanded, Online, ProofParams, SetupParams},
     manifest::{EncryptionInput, NIVCRom, NivcCircuitInputs, OrigoManifest},
   },
-  E1, F, G1, G2,
 };
 use tracing::debug;
 

--- a/client/src/tls.rs
+++ b/client/src/tls.rs
@@ -1,8 +1,8 @@
 // TODO many root_stores ... this could use some cleanup where possible
 use proofs::program::manifest::{EncryptionInput, TLSEncryption};
 use tls_client2::{
-  origo::{DecryptChunk, WitnessData},
   CipherSuite, CipherSuiteKey, Decrypter, ProtocolVersion,
+  origo::{DecryptChunk, WitnessData},
 };
 use tls_core::msgs::{base::Payload, enums::ContentType, message::OpaqueMessage};
 use tracing::debug;

--- a/client/src/tls_client_async2/conn.rs
+++ b/client/src/tls_client_async2/conn.rs
@@ -6,9 +6,9 @@ use std::{
 
 use bytes::Bytes;
 use futures::{
+  AsyncRead, AsyncWrite, SinkExt,
   channel::mpsc::{Receiver, SendError, Sender},
   sink::SinkMapErr,
-  AsyncRead, AsyncWrite, SinkExt,
 };
 use tokio_util::{
   compat::{Compat, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt},

--- a/client/src/tlsn.rs
+++ b/client/src/tlsn.rs
@@ -3,12 +3,12 @@
 use std::time::Duration;
 
 use http_body_util::BodyExt;
-use hyper::{body::Bytes, Request};
+use hyper::{Request, body::Bytes};
 use p256::pkcs8::DecodePublicKey;
 use serde::{Deserialize, Serialize};
 use tlsn_core::proof::SessionProof;
 pub use tlsn_core::proof::TlsProof;
-use tlsn_prover::tls::{state::Closed, Prover};
+use tlsn_prover::tls::{Prover, state::Closed};
 use tracing::debug;
 
 use crate::errors;

--- a/client/src/tlsn_native.rs
+++ b/client/src/tlsn_native.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
 
 use http_body_util::Full;
-use hyper::{body::Bytes, Request};
+use hyper::{Request, body::Bytes};
 use rustls::ClientConfig;
-use tlsn_prover::tls::{state::Closed, Prover, ProverConfig};
+use tlsn_prover::tls::{Prover, ProverConfig, state::Closed};
 use tokio_rustls::TlsConnector;
 use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
 

--- a/client/src/tlsn_wasm32.rs
+++ b/client/src/tlsn_wasm32.rs
@@ -1,5 +1,5 @@
-use futures::{channel::oneshot, AsyncWriteExt};
-use tlsn_prover::tls::{state::Closed, Prover, ProverConfig};
+use futures::{AsyncWriteExt, channel::oneshot};
+use tlsn_prover::tls::{Prover, ProverConfig, state::Closed};
 use wasm_bindgen_futures::spawn_local;
 use ws_stream_wasm::*;
 

--- a/client_ios/Cargo.toml
+++ b/client_ios/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name   ="client_ios"
-version="0.6.0"
-edition="2021"
-build  ="build.rs"
-publish=false
+name             ="client_ios"
+version          ="0.6.0"
+build            ="build.rs"
+publish          =false
+edition.workspace=true
 
 [lib]
 crate-type=["staticlib"]

--- a/client_wasm/Cargo.toml
+++ b/client_wasm/Cargo.toml
@@ -10,13 +10,13 @@ crate-type=["cdylib", "rlib"]
 
 [dependencies]
 client              ={ workspace=true, features=["websocket"] }
-js-sys              ="0.3.64"
-serde-wasm-bindgen  ="0.6.1"
+js-sys              ="0.3.77"
+serde-wasm-bindgen  ="0.6.5"
 serde_json          ={ workspace=true }
 tracing             ={ workspace=true }
-wasm-bindgen        ="=0.2.93"
+wasm-bindgen        ="=0.2.100"
 wasm-bindgen-rayon  ={ workspace=true }
-wasm-bindgen-futures="=0.4.43"
+wasm-bindgen-futures="=0.4.50"
 tracing-subscriber  ={ workspace=true, features=["time"] }
 tracing-web         ="0.1.2"
 

--- a/notary/Cargo.toml
+++ b/notary/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name   ="notary"
-version="0.6.0"
-edition="2021"
-build  ="build.rs"
+name             ="notary"
+version          ="0.6.0"
+build            ="build.rs"
+edition.workspace=true
 
 [features]
 default                                      =["tee-dummy-token-generator"]

--- a/notary/src/axum_websocket.rs
+++ b/notary/src/axum_websocket.rs
@@ -40,10 +40,10 @@
 //!
 //! ```
 //! use axum::{
+//!   Router,
 //!   extract::ws::{WebSocket, WebSocketUpgrade},
 //!   response::{IntoResponse, Response},
 //!   routing::get,
-//!   Router,
 //! };
 //!
 //! let app = Router::new().route("/ws", get(handler));
@@ -72,13 +72,13 @@
 //!
 //! ```
 //! use axum::{
+//!   Router,
 //!   extract::{
-//!     ws::{WebSocket, WebSocketUpgrade},
 //!     State,
+//!     ws::{WebSocket, WebSocketUpgrade},
 //!   },
 //!   response::Response,
 //!   routing::get,
-//!   Router,
 //! };
 //!
 //! #[derive(Clone)]
@@ -105,8 +105,8 @@
 //!
 //! ```rust,no_run
 //! use axum::{
-//!   extract::ws::{Message, WebSocket},
 //!   Error,
+//!   extract::ws::{Message, WebSocket},
 //! };
 //! use futures_util::{
 //!   sink::SinkExt,
@@ -140,25 +140,25 @@ use std::{
 };
 
 use async_trait::async_trait;
-use axum::{body::Bytes, extract::FromRequestParts, response::Response, Error};
+use axum::{Error, body::Bytes, extract::FromRequestParts, response::Response};
 use axum_core::body::Body;
 use futures_util::{
   sink::{Sink, SinkExt},
   stream::{Stream, StreamExt},
 };
 use http::{
+  Method, StatusCode,
   header::{self, HeaderMap, HeaderName, HeaderValue},
   request::Parts,
-  Method, StatusCode,
 };
 use hyper_util::rt::TokioIo;
 use sha1::{Digest, Sha1};
 use tokio_tungstenite::{
+  WebSocketStream,
   tungstenite::{
     self as ts,
     protocol::{self, WebSocketConfig},
   },
-  WebSocketStream,
 };
 use tracing::error;
 
@@ -257,10 +257,10 @@ impl<F> WebSocketUpgrade<F> {
   ///
   /// ```
   /// use axum::{
+  ///   Router,
   ///   extract::ws::{WebSocket, WebSocketUpgrade},
   ///   response::{IntoResponse, Response},
   ///   routing::get,
-  ///   Router,
   /// };
   ///
   /// let app = Router::new().route("/ws", get(handler));
@@ -457,10 +457,11 @@ where S: Send + Sync
 }
 
 fn header_contains(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {
-  let header = if let Some(header) = headers.get(&key) {
-    header
-  } else {
-    return false;
+  let header = match headers.get(&key) {
+    Some(header) => header,
+    _ => {
+      return false;
+    },
   };
 
   if let Ok(header) = std::str::from_utf8(header.as_bytes()) {

--- a/notary/src/main.rs
+++ b/notary/src/main.rs
@@ -6,21 +6,21 @@ use std::{
 };
 
 use axum::{
+  Router,
   extract::{Path, Request, State},
   http::StatusCode,
   response::IntoResponse,
   routing::{get, post},
-  Router,
 };
 use errors::NotaryServerError;
 use hyper::{body::Incoming, server::conn::http1};
 use hyper_util::rt::TokioIo;
 use p256::{ecdsa::SigningKey, elliptic_curve::rand_core, pkcs8::DecodePrivateKey};
 use rustls::{
-  pki_types::{CertificateDer, PrivateKeyDer},
   ServerConfig,
+  pki_types::{CertificateDer, PrivateKeyDer},
 };
-use rustls_acme::{caches::DirCache, AcmeConfig};
+use rustls_acme::{AcmeConfig, caches::DirCache};
 use tokio::{io::AsyncWriteExt, net::TcpListener};
 use tokio_rustls::{LazyConfigAcceptor, TlsAcceptor};
 use tokio_stream::StreamExt;

--- a/notary/src/origo.rs
+++ b/notary/src/origo.rs
@@ -5,9 +5,9 @@ use std::{
 
 use alloy_primitives::utils::keccak256;
 use axum::{
+  Json,
   extract::{self, Query, State},
   response::Response,
-  Json,
 };
 use client::origo::{SignBody, VerifyBody, VerifyReply};
 use hyper::upgrade::Upgraded;
@@ -16,11 +16,11 @@ use k256::{
   ecdsa::SigningKey as Secp256k1SigningKey, elliptic_curve::rand_core, pkcs8::DecodePrivateKey,
 };
 use proofs::{
+  F, G1, G2,
   circuits::{CIRCUIT_SIZE_512, MAX_STACK_HEIGHT},
   errors::ProofError,
-  program::manifest::{compute_ciphertext_digest, InitialNIVCInputs},
+  program::manifest::{InitialNIVCInputs, compute_ciphertext_digest},
   proof::FoldingProof,
-  F, G1, G2,
 };
 use rs_merkle::{Hasher, MerkleTree};
 use serde::{Deserialize, Serialize};
@@ -36,11 +36,12 @@ use web_prover_core::proof::SignedVerificationReply;
 use ws_stream_tungstenite::WsStream;
 
 use crate::{
+  SharedState,
   axum_websocket::WebSocket,
   errors::{NotaryServerError, ProxyError},
   tls_parser::{Direction, Transcript, UnparsedMessage},
   tlsn::ProtocolUpgrade,
-  verifier, SharedState,
+  verifier,
 };
 
 pub struct OrigoSigningKey(pub(crate) Secp256k1SigningKey);

--- a/notary/src/proxy.rs
+++ b/notary/src/proxy.rs
@@ -1,8 +1,8 @@
 use std::{sync::Arc, time::Duration};
 
 use axum::{
-  extract::{self, Query, State},
   Json,
+  extract::{self, Query, State},
 };
 use reqwest::{Request, Response};
 use serde::Deserialize;
@@ -16,7 +16,7 @@ use web_prover_core::{
   proof::TeeProof,
 };
 
-use crate::{errors::NotaryServerError, tee::create_tee_proof, SharedState};
+use crate::{SharedState, errors::NotaryServerError, tee::create_tee_proof};
 
 #[derive(Deserialize)]
 pub struct NotarizeQuery {

--- a/notary/src/tcp.rs
+++ b/notary/src/tcp.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use async_trait::async_trait;
 use axum::{
   extract::FromRequestParts,
-  http::{header, request::Parts, HeaderValue, StatusCode},
+  http::{HeaderValue, StatusCode, header, request::Parts},
   response::Response,
 };
 use axum_core::body::Body;
@@ -75,9 +75,8 @@ impl TcpUpgrade {
 }
 
 pub fn header_eq(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {
-  if let Some(header) = headers.get(&key) {
-    header.as_bytes().eq_ignore_ascii_case(value.as_bytes())
-  } else {
-    false
+  match headers.get(&key) {
+    Some(header) => header.as_bytes().eq_ignore_ascii_case(value.as_bytes()),
+    _ => false,
   }
 }

--- a/notary/src/tee.rs
+++ b/notary/src/tee.rs
@@ -16,7 +16,7 @@ use hyper_util::rt::TokioIo;
 use serde::Deserialize;
 use tokio::{
   io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-  time::{timeout, Duration},
+  time::{Duration, timeout},
 };
 use tokio_stream::StreamExt;
 use tokio_util::{
@@ -33,11 +33,11 @@ use web_prover_core::{
 use ws_stream_tungstenite::WsStream;
 
 use crate::{
+  SharedState,
   axum_websocket::WebSocket,
   errors::NotaryServerError,
   origo::{proxy_service, sign_verification},
   tlsn::ProtocolUpgrade,
-  SharedState,
 };
 
 pub fn bytes_to_ascii(bytes: Vec<u8>) -> String {

--- a/notary/src/tls_parser.rs
+++ b/notary/src/tls_parser.rs
@@ -1,7 +1,8 @@
 use std::io::Cursor;
 
-use nom::{bytes::streaming::take, IResult};
+use nom::{IResult, bytes::streaming::take};
 use tls_client2::{
+  Certificate, CipherSuite, CipherSuiteKey,
   hash_hs::HandshakeHashBuffer,
   internal::msgs::hsjoiner::HandshakeJoiner,
   tls_core::{
@@ -16,11 +17,10 @@ use tls_client2::{
     },
     verify::{construct_tls13_server_verify_message, verify_tls13},
   },
-  Certificate, CipherSuite, CipherSuiteKey,
 };
 use tls_parser::{
-  parse_tls_message_handshake, ClientHello, TlsClientHelloContents, TlsMessage,
-  TlsMessageHandshake, TlsServerHelloContents,
+  ClientHello, TlsClientHelloContents, TlsMessage, TlsMessageHandshake, TlsServerHelloContents,
+  parse_tls_message_handshake,
 };
 use tracing::{debug, error, info, trace};
 

--- a/notary/src/tlsn.rs
+++ b/notary/src/tlsn.rs
@@ -18,10 +18,10 @@ use uuid::Uuid;
 use ws_stream_tungstenite::WsStream;
 
 use crate::{
+  SharedState,
   axum_websocket::{WebSocket, WebSocketUpgrade},
   errors::NotaryServerError,
-  tcp::{header_eq, TcpUpgrade},
-  SharedState,
+  tcp::{TcpUpgrade, header_eq},
 };
 // TODO: use this place of our local file once this gets merged: https://github.com/tokio-rs/axum/issues/2848
 // use axum::extract::ws::{WebSocket, WebSocketUpgrade};

--- a/notary/src/verifier.rs
+++ b/notary/src/verifier.rs
@@ -7,9 +7,9 @@ use std::collections::HashMap;
 
 use client_side_prover::supernova::snark::{CompressedSNARK, VerifierKey};
 use proofs::{
-  circuits::{construct_setup_data, PROVING_PARAMS_512},
-  program::data::{CircuitData, Offline, Online, SetupParams},
   E1, F, G1, G2, S1, S2,
+  circuits::{PROVING_PARAMS_512, construct_setup_data},
+  program::data::{CircuitData, Offline, Online, SetupParams},
 };
 use tracing::debug;
 

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name   ="proofs"
-version="0.6.0"
-edition="2021"
-publish=false
-build  ="build.rs"
+name             ="proofs"
+version          ="0.6.0"
+publish          =false
+build            ="build.rs"
+edition.workspace=true
 
 [dependencies]
 serde      ={ workspace=true }

--- a/proofs/src/circom/mod.rs
+++ b/proofs/src/circom/mod.rs
@@ -31,7 +31,7 @@ use std::{
   sync::Arc,
 };
 
-use bellpepper_core::{num::AllocatedNum, ConstraintSystem, LinearCombination, SynthesisError};
+use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError, num::AllocatedNum};
 use byteorder::{LittleEndian, ReadBytesExt};
 use ff::PrimeField;
 use r1cs::R1CS;

--- a/proofs/src/circom/wasm_witness.rs
+++ b/proofs/src/circom/wasm_witness.rs
@@ -14,18 +14,21 @@ impl WitnessOutput {
 }
 
 #[wasm_bindgen]
-extern "C" {
+unsafe extern "C" {
+  // Foreign function binding to JavaScript's createWitness
   #[wasm_bindgen(js_namespace = witness, js_name = createWitness)]
-  async fn create_witness_js(input: &JsValue, opcode: u64) -> JsValue;
+  fn create_witness_js(input: &JsValue, opcode: u64) -> js_sys::Promise;
 }
 
 #[wasm_bindgen]
 pub async fn create_witness(input: JsValue, opcode: u64) -> Result<WitnessOutput, JsValue> {
-  // Convert the Rust WitnessInput to a JsValue
-  let js_witnesses_output = create_witness_js(&input, opcode).await;
+  // Call the JavaScript function, which returns a Promise
+  let promise: js_sys::Promise = unsafe { create_witness_js(&input, opcode) };
 
-  // Call JavaScript function and await the Promise
-  info!("result: {:?}", js_witnesses_output);
+  // Await the resolution of the promise
+  let js_witnesses_output = wasm_bindgen_futures::JsFuture::from(promise).await?;
+
+  // Convert the result to a WitnessOutput
   let js_obj = js_sys::Object::from(js_witnesses_output);
   let data_value = js_sys::Reflect::get(&js_obj, &JsValue::from_str("data"))?;
   let array = js_sys::Array::from(&data_value);

--- a/proofs/src/lib.rs
+++ b/proofs/src/lib.rs
@@ -37,7 +37,7 @@ use circom::CircomCircuit;
 use client_side_prover::{
   provider::GrumpkinEngine,
   spartan::batched::BatchedRelaxedR1CSSNARK,
-  supernova::{snark::CompressedSNARK, PublicParams, TrivialCircuit},
+  supernova::{PublicParams, TrivialCircuit, snark::CompressedSNARK},
   traits::{Engine, Group},
 };
 use ff::Field;

--- a/proofs/src/program/manifest.rs
+++ b/proofs/src/program/manifest.rs
@@ -32,27 +32,27 @@ use derive_more::From;
 use ff::Field;
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tls_client2::CipherSuiteKey;
 use tracing::debug;
 use web_proof_circuits_witness_generator::{
-  data_hasher, field_element_to_base10_string,
+  ByteOrPad, data_hasher, field_element_to_base10_string,
   http::{
-    compute_http_witness, headers_to_bytes, parser::parse as http_parse, HttpMaskType,
-    RawHttpMachine,
+    HttpMaskType, RawHttpMachine, compute_http_witness, headers_to_bytes,
+    parser::parse as http_parse,
   },
-  json::{json_value_digest, parser::parse, JsonKey, RawJsonMachine},
-  polynomial_digest, poseidon, ByteOrPad,
+  json::{JsonKey, RawJsonMachine, json_value_digest, parser::parse},
+  polynomial_digest, poseidon,
 };
 use web_prover_core::{http::MAX_HTTP_HEADERS, manifest::Manifest};
 
 use crate::{
+  ProofError,
   circuits::MAX_STACK_HEIGHT,
   program::{
-    data::{CircuitData, FoldInput},
     F, G1,
+    data::{CircuitData, FoldInput},
   },
-  ProofError,
 };
 
 /// HTTP data signal name
@@ -490,8 +490,10 @@ fn build_plaintext_authentication_circuit_inputs<const CIRCUIT_SIZE: usize>(
         (String::from("plaintext"), pt_chunks[i].clone()),
         (
           String::from("ciphertext_digest"),
-          json!(BigInt::from_bytes_le(num_bigint::Sign::Plus, &polynomial_input.to_bytes())
-            .to_str_radix(10)),
+          json!(
+            BigInt::from_bytes_le(num_bigint::Sign::Plus, &polynomial_input.to_bytes())
+              .to_str_radix(10)
+          ),
         ),
       ]);
       private_inputs.push(private_input);

--- a/proofs/src/program/mod.rs
+++ b/proofs/src/program/mod.rs
@@ -12,11 +12,11 @@
 
 use std::sync::Arc;
 
-use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellpepper_core::{ConstraintSystem, SynthesisError, num::AllocatedNum};
 use circom::{r1cs::R1CS, witness::generate_witness_from_generator_type};
 use client_side_prover::{
   supernova::{NonUniformCircuit, RecursiveSNARK, StepCircuit},
-  traits::{snark::default_ck_hint, Dual},
+  traits::{Dual, snark::default_ck_hint},
 };
 use data::{Expanded, InitializedSetup};
 use proof::FoldingProof;
@@ -192,7 +192,7 @@ pub async fn run(
   #[cfg(feature = "timing")]
   let time = std::time::Instant::now();
   for (idx, &op_code) in
-    resized_rom.iter().enumerate().take_while(|(_, &op_code)| op_code != u64::MAX)
+    resized_rom.iter().enumerate().take_while(|&(_, &op_code)| op_code != u64::MAX)
   {
     info!("Step {} of ROM", idx);
     debug!("Opcode = {:?}", op_code);

--- a/proofs/src/program/utils.rs
+++ b/proofs/src/program/utils.rs
@@ -6,8 +6,8 @@
 //!
 //! - `next_rom_index_and_pc`: Computes the next ROM index and program counter.
 use bellpepper_core::{
-  boolean::{AllocatedBit, Boolean},
   LinearCombination,
+  boolean::{AllocatedBit, Boolean},
 };
 use itertools::Itertools;
 use num_bigint::BigInt;

--- a/proofs/src/setup.rs
+++ b/proofs/src/setup.rs
@@ -30,8 +30,8 @@ use client_side_prover::{
 };
 
 use crate::{
-  errors::ProofError, program, program::data::R1CSType, AuxParams, ProverKey, UninitializedSetup,
-  WitnessGeneratorType, E1, S1, S2,
+  AuxParams, E1, ProverKey, S1, S2, UninitializedSetup, WitnessGeneratorType, errors::ProofError,
+  program, program::data::R1CSType,
 };
 
 /// Proving parameters

--- a/proofs/src/tests/mod.rs
+++ b/proofs/src/tests/mod.rs
@@ -11,17 +11,19 @@ use circuits::{
   PLAINTEXT_AUTHENTICATION_512B_R1CS,
 };
 use client_side_prover::supernova::RecursiveSNARK;
-use inputs::{
-  complex_manifest, complex_request_inputs, complex_response_inputs, simple_request_inputs,
-  simple_response_inputs,
-};
 use web_proof_circuits_witness_generator::polynomial_digest;
 
 use super::*;
-use crate::program::{
-  data::{CircuitData, NotExpanded, ProofParams, SetupParams, UninitializedSetup},
-  initialize_setup_data,
-  manifest::{InitialNIVCInputs, NIVCRom, NivcCircuitInputs, OrigoManifest},
+use crate::{
+  program::{
+    data::{CircuitData, NotExpanded, ProofParams, SetupParams, UninitializedSetup},
+    initialize_setup_data,
+    manifest::{InitialNIVCInputs, NIVCRom, NivcCircuitInputs, OrigoManifest},
+  },
+  tests::inputs::{
+    complex_manifest, complex_request_inputs, complex_response_inputs, simple_request_inputs,
+    simple_response_inputs,
+  },
 };
 
 pub(crate) mod inputs;

--- a/web-prover-core/src/http.rs
+++ b/web-prover-core/src/http.rs
@@ -16,6 +16,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
 use tracing::debug;
 pub use web_proof_circuits_witness_generator::json::JsonKey;
 
@@ -684,7 +685,7 @@ pub mod tests {
   #[macro_export]
   macro_rules! request {
     // Match with optional parameters
-    ($($key:ident: $value:expr),* $(,)?) => {{
+    ($($key:ident: $value:expr_2021),* $(,)?) => {{
         let mut request = ManifestRequest {
             method: "GET".to_string(),
             url: "https://example.com".to_string(),


### PR DESCRIPTION
- pin nightly in toolchain.toml
- remove specific nightly usage from CI, and makefile
- migrate to rust 2024 edition
- closes #422 