### PR TITLE
feat: Implement JSON value matching 

### DIFF
--- a/client/src/origo.rs
+++ b/client/src/origo.rs
@@ -169,7 +169,7 @@ pub(crate) async fn proxy_and_sign_and_generate_proof(
   let http_body = compute_http_witness(&flattened_plaintext, HttpMaskType::Body);
   let value = json_value_digest::<{ proofs::circuits::MAX_STACK_HEIGHT }>(
     &http_body,
-    &manifest.response.body.json,
+    &manifest.response.body.json_path,
   )?;
 
   proof.value = Some(String::from_utf8_lossy(&value).into_owned());

--- a/notary/src/errors.rs
+++ b/notary/src/errors.rs
@@ -8,8 +8,6 @@ use thiserror::Error;
 use tlsn_verifier::tls::{VerifierConfigBuilderError, VerifierError};
 use tracing::error;
 
-use crate::tls_parser::Direction;
-
 #[derive(Debug, Error)]
 pub enum ProxyError {
   #[error(transparent)]

--- a/notary/src/origo.rs
+++ b/notary/src/origo.rs
@@ -24,7 +24,6 @@ use proofs::{
 };
 use rs_merkle::{Hasher, MerkleTree};
 use serde::{Deserialize, Serialize};
-use tls_parser::rusticata_macros::debug;
 use tokio::{
   io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
   net::TcpStream,

--- a/proofs/src/program/http.rs
+++ b/proofs/src/program/http.rs
@@ -15,7 +15,6 @@
 
 use std::collections::HashMap;
 
-use ff::derive::bitvec::macros::internal::funty::Fundamental;
 use serde::{Deserialize, Serialize};
 use tracing::debug;
 pub use web_proof_circuits_witness_generator::json::JsonKey;
@@ -157,13 +156,13 @@ impl NotaryResponseBody {
           return false;
         }
         if let Some(n) = actual.as_u64() {
-          return n == expected.as_u64();
+          return n == (*expected as u64);
         }
         if let Some(n) = actual.as_i64() {
-          return n == expected.as_i64();
+          return n == (*expected as i64);
         }
         if let Some(n) = actual.as_f64() {
-          return (n - expected.as_f64()).abs() < f64::EPSILON;
+          return (n - (*expected as f64)).abs() < f64::EPSILON;
         }
         false
       },

--- a/proofs/src/program/http.rs
+++ b/proofs/src/program/http.rs
@@ -376,6 +376,13 @@ impl ManifestResponse {
       return Err(ProofError::InvalidManifest("Expected at least one JSON item".to_string()));
     }
 
+    const MAX_JSON_PATH_LENGTH: usize = 100;
+    if self.body.json_path.len() > MAX_JSON_PATH_LENGTH {
+      return Err(ProofError::InvalidManifest(
+        "Invalid JSON path length: ".to_string() + &self.body.json_path.len().to_string(),
+      ));
+    }
+
     Ok(())
   }
 }
@@ -1126,7 +1133,7 @@ mod tests {
 
   #[test]
   fn test_very_deep_nesting() {
-    // Test different depths: 3, 10, and 100 levels
+    // Test different depths: 5, 25, and 100 levels
     let depths = vec![5, 25, 100];
 
     for depth in depths {

--- a/proofs/src/program/http.rs
+++ b/proofs/src/program/http.rs
@@ -15,8 +15,9 @@
 
 use std::collections::HashMap;
 
+use ff::derive::bitvec::macros::internal::funty::Fundamental;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use serde_json::Value;
 use tracing::debug;
 pub use web_proof_circuits_witness_generator::json::JsonKey;
 
@@ -25,14 +26,269 @@ use crate::{
   program::manifest::{HTTP_1_1, MAX_HTTP_HEADERS},
 };
 
-/// Response body type
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct ResponseBody {
-  /// JSON Keys
-  pub json: Vec<JsonKey>,
+/// A type of response body used to describe conditions in the client `Manifest`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ManifestResponseBody {
+  /// JSON Path containing expected traversal keys and expected value
+  #[serde(rename = "json")] // TODO: Remove after migrating to a JSON DSL
+  pub json_path: Vec<JsonKey>,
+}
 
-  /// JSON Real Value
-  pub json_actual: Option<serde_json::Value>,
+impl TryFrom<&[u8]> for ManifestResponseBody {
+  type Error = ProofError;
+
+  fn try_from(body_bytes: &[u8]) -> Result<Self, Self::Error> {
+    if body_bytes.is_empty() {
+      return Ok(Self { json_path: vec![] });
+    }
+    // Attempt to parse the body as JSON path.
+    let json_path: Vec<JsonKey> = serde_json::from_slice(body_bytes)
+      .map_err(|_| ProofError::InvalidManifest("Failed to parse body as valid JSON".to_string()))?;
+    Ok(Self { json_path })
+  }
+}
+
+/// A type of response body returned by a notary. Must match `ManifestResponseBody` designated
+/// by the client.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NotaryResponseBody {
+  /// Raw JSON value returned by a notary.
+  pub json: Option<serde_json::Value>,
+}
+
+impl TryFrom<&[u8]> for NotaryResponseBody {
+  type Error = ProofError;
+
+  fn try_from(body_bytes: &[u8]) -> Result<Self, Self::Error> {
+    if body_bytes.is_empty() {
+      return Ok(Self { json: None });
+    }
+    // Attempt to parse the body as JSON.
+    let json: Value = serde_json::from_slice(body_bytes)
+      .map_err(|_| ProofError::InvalidManifest("Failed to parse body as valid JSON".to_string()))?;
+    Ok(Self { json: Some(json) })
+  }
+}
+
+impl NotaryResponseBody {
+  /// Verifies if the notary's JSON response matches the client-provided `json_path`.
+  ///
+  /// The `json_path` defines a sequence of keys for traversing the JSON structure.
+  /// Each key specifies either:
+  /// - A string to look for in a JSON object.
+  /// - An index to access an element in a JSON array.
+  /// - A concrete value at the end of the path.
+  ///
+  /// The function traverses the JSON step-by-step, returning `true` if all keys match,
+  /// or `false` otherwise.
+  fn matches_path(&self, json_path: &[JsonKey]) -> bool {
+    if json_path.is_empty() {
+      debug!("Invalid json_path: Path is empty");
+      return false;
+    }
+    let Some(json) = &self.json else {
+      debug!("No JSON data to match against");
+      return false;
+    };
+    self.traverse_json_path(json, json_path)
+  }
+
+  /// Traverses a JSON value using a specified path of keys and verifies if it matches the given
+  /// sequence.
+  ///
+  /// # Arguments
+  /// * `initial_value` - The root JSON value to start traversal from.
+  /// * `json_path` - A sequence of `JsonKey` elements defining the traversal path.
+  ///
+  /// # Returns
+  /// `true` if the traversal successfully matches the sequence or reaches the expected value;
+  /// `false` otherwise.
+  fn traverse_json_path(&self, initial_value: &Value, json_path: &[JsonKey]) -> bool {
+    let mut current = initial_value;
+
+    for (i, key) in json_path.iter().enumerate() {
+      let is_last = i == json_path.len() - 1;
+
+      match key {
+        JsonKey::String(expected) => {
+          if !self.handle_string_key(current, expected, is_last) {
+            return false;
+          }
+          if is_last {
+            return true;
+          }
+          current = current.as_object().and_then(|obj| obj.get(expected)).unwrap();
+        },
+        JsonKey::Num(expected) => {
+          if !self.handle_numeric_key(current, expected, is_last) {
+            return false;
+          }
+          if is_last {
+            return true;
+          }
+          current = current.as_array().and_then(|arr| arr.get(*expected as usize)).unwrap();
+        },
+      }
+    }
+
+    false
+  }
+
+  fn handle_string_key(&self, current: &Value, expected: &str, is_last: bool) -> bool {
+    match current {
+      Value::String(actual) => is_last && actual == expected,
+      Value::Object(obj) => obj.contains_key(expected),
+      _ => {
+        debug!("Expected string or object, found: {:?}", current);
+        false
+      },
+    }
+  }
+
+  fn handle_numeric_key(&self, current: &Value, expected: &usize, is_last: bool) -> bool {
+    match current {
+      Value::Number(actual) => {
+        if !is_last {
+          return false;
+        }
+        if let Some(n) = actual.as_u64() {
+          return n == expected.as_u64();
+        }
+        if let Some(n) = actual.as_i64() {
+          return n == expected.as_i64();
+        }
+        if let Some(n) = actual.as_f64() {
+          return (n - expected.as_f64()).abs() < f64::EPSILON;
+        }
+        false
+      },
+      Value::Array(arr) => expected >= &0 && *expected < arr.len(),
+      _ => {
+        debug!("Expected number or array, found: {:?}", current);
+        false
+      },
+    }
+  }
+}
+
+/// A response the made by the notary for a request from the client. Must match client response.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NotaryResponse {
+  /// Client-designated response recovered from the notary
+  pub response:             ManifestResponse,
+  /// Raw response body from the notary
+  pub notary_response_body: NotaryResponseBody,
+}
+
+impl NotaryResponse {
+  /// Recovers all `Response` fields from the given payloads and creates a `Response` struct.
+  ///
+  /// - `header_bytes`: The bytes representing the HTTP response headers and metadata.
+  /// - `body_bytes`: The bytes representing the HTTP response body.
+  pub fn from_payload(bytes: &[u8]) -> Result<Self, ProofError> {
+    let delimiter = b"\r\n\r\n";
+    let split_position = bytes
+      .windows(delimiter.len())
+      .position(|window| window == delimiter)
+      .ok_or_else(|| ProofError::InvalidManifest("Invalid HTTP format".to_string()))?;
+
+    let (header_bytes, rest) = bytes.split_at(split_position);
+    let body_bytes = &rest[delimiter.len()..];
+
+    let (headers, status, version, message) = Self::parse_header(header_bytes)?;
+    // We don't even parse the body here because we don't care about JSON path at this point
+    let body = ManifestResponseBody::default();
+    let response = ManifestResponse { status, version, message, headers, body };
+    let notary_response_body = NotaryResponseBody::try_from(body_bytes)?;
+    Ok(Self { response, notary_response_body })
+  }
+
+  /// Parses the HTTP response header from the given bytes.
+  ///
+  /// # Arguments
+  ///
+  /// * `header_bytes`: The bytes representing the HTTP response header.
+  ///
+  /// # Returns
+  ///
+  /// The parsed HTTP response header.
+  fn parse_header(
+    header_bytes: &[u8],
+  ) -> Result<(HashMap<String, String>, String, String, String), ProofError> {
+    let headers_str = std::str::from_utf8(header_bytes).map_err(|_| {
+      ProofError::InvalidManifest("Failed to interpret headers as valid UTF-8".to_string())
+    })?;
+    let mut headers = HashMap::new();
+    let mut status = String::new();
+    let mut version = String::new();
+    let mut message = String::new();
+
+    for (i, line) in headers_str.lines().enumerate() {
+      if line.trim().is_empty() {
+        continue; // Skip empty lines
+      }
+      if i == 0 {
+        // Process the first line as the HTTP response start-line
+        let parts: Vec<&str> = line.split_whitespace().collect();
+        if parts.len() < 3 {
+          return Err(ProofError::InvalidManifest("Invalid HTTP response start-line".to_string()));
+        }
+        version = parts[0].to_string();
+        status = parts[1].to_string();
+        message = parts[2..].join(" ");
+      } else {
+        // Process subsequent lines as headers
+        if let Some((key, value)) = line.split_once(": ") {
+          headers.insert(key.to_string(), value.to_string());
+        } else {
+          return Err(ProofError::InvalidManifest(format!("Invalid header line: {}", line)));
+        }
+      }
+    }
+    Ok((headers, status, version, message))
+  }
+
+  /// Tests matching between notary response, `self`,  and client-designated response, `other`.
+  /// Returns true if at least all values in `other` are also present in `self`.
+  pub fn matches_client_manifest(&self, other: &ManifestResponse) -> bool {
+    if self.response.status != other.status
+      || self.response.version != other.version
+      || self.response.message != other.message
+    {
+      debug!("Exact matches for status, version, or message do not match");
+      return false;
+    }
+
+    // Ensure all headers in `other` are present in `self`
+    for (key, other_value) in &other.headers {
+      let value =
+        self.response.headers.get(key).or_else(|| self.response.headers.get(&key.to_lowercase()));
+      if let Some(actual_value) = value {
+        if actual_value != other_value {
+          debug!(
+            "Header mismatch for key: {}: expected={}, actual={}",
+            key, other_value, actual_value
+          );
+          return false;
+        }
+      } else {
+        debug!("Header key not present in self: {}", key);
+        return false;
+      }
+    }
+
+    // Check if the `body` of `other` matches the `json_path` within `self`.
+    if !self.notary_response_body.matches_path(&other.body.json_path) {
+      debug!(
+        "JSON path does not match. notary_response_body={:?}, json_path={:?}",
+        self.notary_response_body, other.body.json_path,
+      );
+      return false;
+    }
+
+    debug!("Client response matches");
+    true
+  }
 }
 
 /// Default HTTP version
@@ -54,7 +310,7 @@ pub struct ManifestResponse {
   /// HTTP headers to lock
   pub headers: HashMap<String, String>,
   /// HTTP body keys
-  pub body:    ResponseBody,
+  pub body:    ManifestResponseBody,
 }
 
 impl ManifestResponse {
@@ -116,173 +372,12 @@ impl ManifestResponse {
     }
 
     // When Content-Type is application/json, we expect at least one JSON item
-    if content_type == "application/json" && self.body.json.is_empty() {
+    if content_type == "application/json" && self.body.json_path.is_empty() {
       return Err(ProofError::InvalidManifest("Expected at least one JSON item".to_string()));
     }
 
     Ok(())
   }
-
-  /// Recovers all `Response` fields from the given payloads and creates a `Response` struct.
-  ///
-  /// - `header_bytes`: The bytes representing the HTTP response headers and metadata.
-  /// - `body_bytes`: The bytes representing the HTTP response body.
-  pub fn from_payload(bytes: &[u8]) -> Result<Self, ProofError> {
-    let delimiter = b"\r\n\r\n";
-    let split_position = bytes
-      .windows(delimiter.len())
-      .position(|window| window == delimiter)
-      .ok_or_else(|| ProofError::InvalidManifest("Invalid HTTP format".to_string()))?;
-
-    let (header_bytes, rest) = bytes.split_at(split_position);
-    let body_bytes = &rest[delimiter.len()..];
-
-    let (headers, status, version, message) = Self::parse_header(header_bytes)?;
-    let body = Self::parse_body(body_bytes)?;
-    Ok(Self { status, version, message, headers, body })
-  }
-
-  /// This function parses the HTTP response body from the given bytes.
-  ///
-  /// # Arguments
-  ///
-  /// * `body_bytes`: The bytes representing the HTTP response body.
-  ///
-  /// # Returns
-  ///
-  /// The parsed HTTP response body.
-  fn parse_body(body_bytes: &[u8]) -> Result<ResponseBody, ProofError> {
-    if body_bytes.is_empty() {
-      return Ok(ResponseBody { json: Vec::new(), json_actual: None });
-    }
-
-    let body_json: Value = serde_json::from_slice(body_bytes)
-      .map_err(|_| ProofError::InvalidManifest("Failed to parse body as valid JSON".to_string()))?;
-
-    let body = ResponseBody {
-      json:        match &body_json {
-        Value::Object(map) => map.keys().cloned().map(JsonKey::String).collect(),
-        _ =>
-          return Err(ProofError::InvalidManifest("Body is not a valid JSON object".to_string())),
-      },
-      json_actual: Some(body_json),
-    };
-
-    Ok(body)
-  }
-
-  /// Parses the HTTP response header from the given bytes.
-  ///
-  /// # Arguments
-  ///
-  /// * `header_bytes`: The bytes representing the HTTP response header.
-  ///
-  /// # Returns
-  ///
-  /// The parsed HTTP response header.
-  fn parse_header(
-    header_bytes: &[u8],
-  ) -> Result<(HashMap<String, String>, String, String, String), ProofError> {
-    let headers_str = std::str::from_utf8(header_bytes).map_err(|_| {
-      ProofError::InvalidManifest("Failed to interpret headers as valid UTF-8".to_string())
-    })?;
-    let mut headers = HashMap::new();
-    let mut status = String::new();
-    let mut version = String::new();
-    let mut message = String::new();
-
-    for (i, line) in headers_str.lines().enumerate() {
-      if line.trim().is_empty() {
-        continue; // Skip empty lines
-      }
-      if i == 0 {
-        // Process the first line as the HTTP response start-line
-        let parts: Vec<&str> = line.split_whitespace().collect();
-        if parts.len() < 3 {
-          return Err(ProofError::InvalidManifest("Invalid HTTP response start-line".to_string()));
-        }
-        version = parts[0].to_string();
-        status = parts[1].to_string();
-        message = parts[2..].join(" ");
-      } else {
-        // Process subsequent lines as headers
-        if let Some((key, value)) = line.split_once(": ") {
-          headers.insert(key.to_string(), value.to_string());
-        } else {
-          return Err(ProofError::InvalidManifest(format!("Invalid header line: {}", line)));
-        }
-      }
-    }
-    Ok((headers, status, version, message))
-  }
-
-  /// Performs a test between two response structures. Returns true if `other` contains
-  /// at least all the values also present in `self`.
-  pub fn is_subset_of(&self, other: &ManifestResponse) -> bool {
-    if self.status != other.status || self.version != other.version || self.message != other.message
-    {
-      debug!("Exact matches don't match");
-      return false;
-    }
-
-    // Check if all headers in `self` are present in `other`
-    for (key, value) in &self.headers {
-      let expected_value =
-        other.headers.get(key).or_else(|| other.headers.get(&key.to_lowercase()));
-      if let Some(other_value) = expected_value {
-        if other_value != value {
-          debug!("other_value={} doesnt match value={}", other_value, value);
-          return false;
-        }
-      } else {
-        debug!("missing key={}", key);
-        return false;
-      }
-    }
-
-    if let Some(other_json_actual) = other.body.json_actual.as_ref() {
-      if !self.body.json.is_empty() && !json_contains_path(other_json_actual, &self.body.json) {
-        debug!("Missing JSON path={:?}, actual_json={:?}", self.body.json, other_json_actual);
-        return false;
-      }
-    } else {
-      debug!("Missing json_actual in other response");
-      return false;
-    }
-
-    // All checks passed
-    debug!("All checks passed");
-    true
-  }
-}
-
-fn json_contains_path(json: &serde_json::Value, expected_path: &[JsonKey]) -> bool {
-  let mut current = json;
-
-  for key in expected_path {
-    match key {
-      JsonKey::String(s) =>
-        if let Some(value) = current.get(s) {
-          current = value;
-        } else {
-          debug!("Key `{}` not found in path {:?}", s, expected_path);
-          return false;
-        },
-      JsonKey::Num(n) =>
-        if let Some(array) = current.as_array() {
-          if let Some(value) = array.get(*n) {
-            current = value;
-          } else {
-            debug!("Array index `{}` out of bounds in path {:?}", n, expected_path);
-            return false;
-          }
-        } else {
-          debug!("Expected array at key {:?} in path {:?}", n, expected_path);
-          return false;
-        },
-    }
-  }
-  true
 }
 
 /// Template variable type
@@ -449,12 +544,15 @@ impl ManifestRequest {
 }
 
 #[cfg(test)]
-pub(crate) mod tests {
+mod tests {
+
+  use serde_json::json;
+
   use super::*;
 
   #[macro_export]
   /// Creates a new HTTP request with optional parameters.
-  macro_rules! create_request {
+  macro_rules! request {
     // Match with optional parameters
     ($($key:ident: $value:expr),* $(,)?) => {{
         let mut request = ManifestRequest {
@@ -487,7 +585,7 @@ pub(crate) mod tests {
 
   #[macro_export]
   /// Creates a new HTTP response with optional parameters.
-  macro_rules! create_response {
+  macro_rules! response {
     // Match with optional parameters
     ($($key:ident: $value:expr),* $(,)?) => {{
         let mut response = ManifestResponse {
@@ -497,9 +595,12 @@ pub(crate) mod tests {
             headers: std::collections::HashMap::from([
                 ("Content-Type".to_string(), "application/json".to_string())
             ]),
-            body: ResponseBody {
-                json: vec![JsonKey::String("key1".to_string()), JsonKey::String("key2".to_string())],
-                json_actual: None,
+            body: ManifestResponseBody {
+                json_path: vec![
+                    JsonKey::String("key1".to_string()),
+                    JsonKey::String("key2".to_string()),
+                    JsonKey::Num(3)
+                ]
             },
         };
 
@@ -512,59 +613,89 @@ pub(crate) mod tests {
     }};
   }
 
-  #[test]
-  fn test_parse_response() {
-    let header_bytes: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
-    let body_bytes: &[u8] = br#"{"key1": "value1", "key2": "value2"}"#;
-    let response = ManifestResponse::from_payload(&[header_bytes, body_bytes].concat()).unwrap();
-    assert_eq!(response.status, "200");
-    assert_eq!(response.version, "HTTP/1.1");
-    assert_eq!(response.message, "OK");
-    assert_eq!(response.headers.len(), 1);
-    assert_eq!(response.headers.get("Content-Type").unwrap(), "application/json");
-    assert_eq!(response.body.json.len(), 2);
-    assert_eq!(response.body.json[0], JsonKey::String("key1".to_string()));
-    assert_eq!(response.body.json[1], JsonKey::String("key2".to_string()));
+  #[macro_export]
+  /// Creates a `NotaryResponse` by taking a `ManifestResponse` and optional overrides for
+  /// `NotaryResponseBody`.
+  macro_rules! notary_response {
+    // Match with ManifestResponse and optional overrides for NotaryResponseBody
+    ($response:expr, $($key:ident: $value:expr),* $(,)?) => {{
+        let mut notary_response_body = NotaryResponseBody {
+            json: Some(serde_json::json!({})), // Default to empty JSON
+        };
+
+        // Apply custom key-value overrides for NotaryResponseBody
+        $(
+            notary_response_body.$key = $value;
+        )*
+
+        // Return the complete NotaryResponse
+        NotaryResponse {
+            response: $response,
+            notary_response_body,
+        }
+    }};
   }
 
   #[test]
-  fn test_matches_other_response() {
-    let sourced_response = create_response!(
-        headers: HashMap::from([("Content-Type".to_string(), "application/json".to_string())]),
-        body: ResponseBody {
-            json: vec![JsonKey::String("key1".to_string()), JsonKey::String("key2".to_string())],
-            json_actual: Some(json!({"key1": {"key2": "value1"}})),
-        }
+  fn test_parse_response() {
+    let header_bytes: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
+    let body = serde_json::json!({"key1": { "key2": 3 }});
+    let response =
+      NotaryResponse::from_payload(&[header_bytes, body.to_string().as_bytes()].concat()).unwrap();
+    assert_eq!(response.response.status, "200");
+    assert_eq!(response.response.version, "HTTP/1.1");
+    assert_eq!(response.response.message, "OK");
+    assert_eq!(response.response.headers.len(), 1);
+    assert_eq!(response.response.headers.get("Content-Type").unwrap(), "application/json");
+    assert_eq!(response.response.body.json_path.len(), 0);
+    assert_eq!(response.notary_response_body.json, Some(body));
+  }
+
+  #[test]
+  fn test_notary_matches_other_response() {
+    let response = response!();
+    let notary_response = notary_response!(
+      response.clone(),
+      json: Some(serde_json::json!({
+            "key1": {"key2": 3},
+        })),
     );
 
-    // Matches a perfect match
-    assert!(sourced_response.is_subset_of(&sourced_response));
+    // Is a perfect match with itself
+    assert!(notary_response.matches_client_manifest(&response));
+    assert!(notary_response.matches_client_manifest(&notary_response.response));
 
     // Fails if it doesn't match directly
-    let non_matching_response = create_response!(status: "201".to_string());
-    assert!(!sourced_response.is_subset_of(&non_matching_response));
+    let non_matching_response = response!(status: "201".to_string());
+    assert!(!notary_response.matches_client_manifest(&non_matching_response));
 
     // Superset case
     let response_superset = {
-      let mut res = sourced_response.clone();
-      res.headers.insert("extra".to_string(), "header".to_string());
-      res.body.json.push(JsonKey::String("key3".to_string()));
+      let mut res = notary_response.clone();
+      res.response.headers.insert("extra".to_string(), "header".to_string());
+      res.response.body.json_path = notary_response.response.body.json_path.clone();
+      res.response.body.json_path.push(JsonKey::Num(3));
       res
     };
-    assert!(sourced_response.is_subset_of(&response_superset));
+    assert!(response_superset.matches_client_manifest(&response));
   }
 
   #[test]
   fn test_response_with_missing_body() {
     let header_bytes: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\r\n";
-    let body_bytes: &[u8] = br#""#;
+    let empty_body: &[u8] = br#""#;
 
-    let response = ManifestResponse::from_payload(&[header_bytes, body_bytes].concat()).unwrap();
-    let expected_response = create_response!(
+    let actual = NotaryResponse::from_payload(&[header_bytes, empty_body].concat()).unwrap();
+
+    let expected = NotaryResponse {
+      response:             response!(
         headers: HashMap::from([("Content-Type".to_string(), "text/plain".to_string())]),
-        body: ResponseBody { json: vec![], json_actual: None}
-    );
-    assert_eq!(response, expected_response);
+        body: ManifestResponseBody { json_path: vec![] }
+      ),
+      notary_response_body: NotaryResponseBody { json: None },
+    };
+
+    assert_eq!(actual, expected);
   }
 
   #[test]
@@ -572,20 +703,19 @@ pub(crate) mod tests {
     let header_bytes: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
     let invalid_body_bytes: &[u8] = br#"This is not JSON"#;
 
-    let result = ManifestResponse::from_payload(&[header_bytes, invalid_body_bytes].concat());
+    let result = NotaryResponse::from_payload(&[header_bytes, invalid_body_bytes].concat());
     assert!(result.is_err());
 
-    match result {
-      Err(ProofError::InvalidManifest(msg)) => {
-        assert!(msg.contains("Failed to parse body as valid JSON"));
-      },
-      _ => panic!("Expected invalid manifest error for body parsing"),
+    if let Err(ProofError::InvalidManifest(msg)) = result {
+      assert!(msg.contains("Failed to parse body as valid JSON"));
+    } else {
+      panic!("Expected an invalid manifest error for body parsing");
     }
   }
 
   #[test]
   fn test_validate_invalid_status() {
-    let response = create_response!(
+    let response = response!(
         status: "404".to_string(), // Invalid status code
         message: "Not Found".to_string()
     );
@@ -603,11 +733,10 @@ pub(crate) mod tests {
 
   #[test]
   fn test_validate_empty_message() {
-    let response = create_response!(
-        message: "".to_string(), // Invalid, empty message
-        body: ResponseBody { json: vec![JsonKey::String("key1".to_string())], json_actual: None }
+    let invalid_response = response!(
+        message: "".to_string(),
     );
-    let result = response.validate();
+    let result = invalid_response.validate();
     assert!(result.is_err());
 
     if let Err(ProofError::InvalidManifest(msg)) = result {
@@ -621,14 +750,22 @@ pub(crate) mod tests {
   fn test_valid_response_with_optional_body() {
     let header_bytes: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
     let body_bytes: &[u8] = br#"{"key1": "value1"}"#;
-    let response = ManifestResponse::from_payload(&[header_bytes, body_bytes].concat()).unwrap();
 
-    let expected_response = create_response!(
-        body: ResponseBody {
-            json: vec![JsonKey::String("key1".to_string())],
-            json_actual: Some(json!({"key1": "value1"}))
+    let response = NotaryResponse::from_payload(&[header_bytes, body_bytes].concat()).unwrap();
+
+    let manifest_response = response!(
+        headers: std::collections::HashMap::from([
+            ("Content-Type".to_string(), "application/json".to_string())
+        ]),
+        body: ManifestResponseBody {
+            json_path: vec![],
         }
     );
+    let expected_response = notary_response!(
+        manifest_response,
+        json: Some(serde_json::json!({"key1": "value1"}))
+    );
+
     assert_eq!(response, expected_response);
   }
 
@@ -637,36 +774,22 @@ pub(crate) mod tests {
     let header_bytes: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n";
     let empty_body_bytes: &[u8] = br#"{}"#;
 
-    let result = ManifestResponse::from_payload(&[header_bytes, empty_body_bytes].concat());
-    assert!(result.is_ok());
+    let notary_response =
+      NotaryResponse::from_payload(&[header_bytes, empty_body_bytes].concat()).unwrap();
 
-    let response = result.unwrap();
-    assert_eq!(response.body.json.len(), 0);
+    assert_eq!(notary_response.response.body.json_path.len(), 0);
+    assert_eq!(notary_response.notary_response_body.json, Some(serde_json::json!({})));
   }
 
   #[test]
   fn test_subset_with_missing_key_in_other() {
-    let base_response = create_response!(
-        status: "200".to_string(),
-        version: "HTTP/1.1".to_string(),
-        message: "OK".to_string(),
-        headers: HashMap::from([("Content-Type".to_string(), "application/json".to_string())]),
-        body: ResponseBody {
-            json: vec![JsonKey::String("key1".to_string()), JsonKey::String("key2".to_string())],
-            json_actual: None
+    let base_response = notary_response!(response!(),);
+    let other_response = response!(
+        body: ManifestResponseBody {
+            json_path: vec![JsonKey::String("key1".to_string())],
         }
     );
-    let other_response = create_response!(
-        status: "200".to_string(),
-        version: "HTTP/1.1".to_string(),
-        message: "OK".to_string(),
-        headers: HashMap::from([("Content-Type".to_string(), "application/json".to_string())]),
-        body: ResponseBody {
-            json: vec![JsonKey::String("key1".to_string())],  // Missing "key2"
-            json_actual: Some(json!({"key1": {"thing2": "value2"}})),
-        }
-    );
-    assert!(!base_response.is_subset_of(&other_response));
+    assert!(!base_response.matches_client_manifest(&other_response));
   }
 
   #[test]
@@ -773,7 +896,7 @@ pub(crate) mod tests {
 
   #[test]
   fn test_request_subset_comparison() {
-    let base_request = create_request!(
+    let base_request = request!(
         method: "GET".to_string(),
         url: "/path".to_string(),
         headers: HashMap::from([("Authorization".to_string(), "Bearer token".to_string())]),
@@ -791,26 +914,46 @@ pub(crate) mod tests {
     assert!(!base_request.is_subset_of(&other_request));
   }
 
+  #[macro_export]
+  /// Creates a response body with a given serde_json::Value
+  macro_rules! notary_body {
+    ($($key:tt : $value:tt),* $(,)?) => {{
+        NotaryResponseBody {
+            json: Some(serde_json::json!({
+                $(
+                    $key: $value
+                ),*
+            }))
+        }
+    }};
+}
+
   #[test]
   fn test_json_contains_path_valid_object_path() {
-    let json = json!({
+    let json = notary_body!(
         "key1": {
             "key2": {
                 "key3": "value"
             }
         }
-    });
-    let path = vec![
+    );
+    let mut path = vec![
       JsonKey::String("key1".to_string()),
       JsonKey::String("key2".to_string()),
       JsonKey::String("key3".to_string()),
     ];
-    assert!(json_contains_path(&json, &path));
+    assert!(json.matches_path(&path));
+
+    path.push(JsonKey::String("value".to_string()));
+    assert!(json.matches_path(&path));
+
+    path.push(JsonKey::String("invalid".to_string()));
+    assert!(!json.matches_path(&path));
   }
 
   #[test]
   fn test_json_contains_path_valid_array_path() {
-    let json = json!({
+    let json = notary_body!(
         "key1": [
             {
                 "key2": "value1"
@@ -819,73 +962,194 @@ pub(crate) mod tests {
                 "key3": "value2"
             }
         ]
-    });
+    );
     let path = vec![
       JsonKey::String("key1".to_string()),
       JsonKey::Num(1),
       JsonKey::String("key3".to_string()),
+      JsonKey::String("value2".to_string()),
     ];
-    assert!(json_contains_path(&json, &path));
+    assert!(json.matches_path(&path));
   }
 
   #[test]
   fn test_json_contains_path_invalid_key() {
-    let json = json!({
+    let json = notary_body!(
         "key1": {
             "key2": "value"
         }
-    });
+    );
     let path =
       vec![JsonKey::String("key1".to_string()), JsonKey::String("invalid_key".to_string())];
-    assert!(!json_contains_path(&json, &path));
+    assert!(!json.matches_path(&path));
   }
 
   #[test]
   fn test_json_contains_path_invalid_array_index() {
-    let json = json!({
+    let json = notary_body!(
         "key1": [
             "value1",
             "value2"
         ]
-    });
+    );
     let path = vec![
       JsonKey::String("key1".to_string()),
       JsonKey::Num(3), // Out of bounds
     ];
-    assert!(!json_contains_path(&json, &path));
+    assert!(!json.matches_path(&path));
   }
 
   #[test]
   fn test_json_contains_path_index_on_non_array() {
-    let json = json!({
+    let json = notary_body!(
         "key1": {
             "key2": "value"
         }
-    });
+    );
     let path = vec![
       JsonKey::String("key1".to_string()),
       JsonKey::Num(0), // Applying index on a non-array
     ];
-    assert!(!json_contains_path(&json, &path));
+    assert!(!&json.matches_path(&path));
   }
 
   #[test]
-  fn test_json_contains_path_nested_objects() {
-    let json = json!({
+  fn test_empty_path() {
+    let json = notary_body!(
         "key1": {
             "key2": {
-                "key3": {
-                    "key4": "value"
-                }
+                "key3": "value"
             }
         }
-    });
-    let path = vec![
-      JsonKey::String("key1".to_string()),
-      JsonKey::String("key2".to_string()),
-      JsonKey::String("key3".to_string()),
-      JsonKey::String("key4".to_string()),
+    );
+    let path: Vec<JsonKey> = vec![];
+    assert!(!json.matches_path(&path));
+  }
+
+  #[test]
+  fn test_empty_body() {
+    let json = notary_body!();
+    let mut path: Vec<JsonKey> = vec![];
+    assert!(!json.matches_path(&path));
+
+    path.push(JsonKey::String("key1".to_string()));
+    assert!(!json.matches_path(&path));
+  }
+
+  #[test]
+  fn test_number_matching() {
+    let test_cases = vec![
+      // Unsigned integers
+      (json!({"val": 42u64}), 42, true),
+      // Signed integers
+      (json!({"val": -42}), -42, true),
+      // Floating point
+      (json!({"val": 42.0}), 42, true),
+      // Large numbers
+      (json!({"val": u64::MAX}), u64::MAX as i64, true),
+      // Mismatched types
+      (json!({"val": "42"}), 42, false),
+      // Edge cases
+      (json!({"val": 42.000001}), 42, false),
     ];
-    assert!(json_contains_path(&json, &path));
+
+    for (json, expected, should_match) in test_cases {
+      let body = NotaryResponseBody { json: Some(json.clone()) };
+      assert_eq!(
+        body.matches_path(&[JsonKey::String("val".to_string()), JsonKey::Num(expected as usize)]),
+        should_match,
+        "Failed for value: {:?}, expected: {}",
+        json,
+        expected
+      );
+    }
+  }
+
+  #[test]
+  fn test_nested_array_path() {
+    let json = notary_body!(
+        "data": [
+            [1, 2, 3],
+            [4, 5, 6]
+        ]
+    );
+    assert!(json.matches_path(&[
+      JsonKey::String("data".to_string()),
+      JsonKey::Num(1),
+      JsonKey::Num(1),
+      JsonKey::Num(5),
+    ]));
+  }
+
+  #[test]
+  fn test_mixed_types_in_array() {
+    let json = notary_body!(
+        "mixed": [
+            42,
+            "string",
+            { "key": "value" },
+            [1, 2, 3]
+        ]
+    );
+    assert!(json.matches_path(&[
+      JsonKey::String("mixed".to_string()),
+      JsonKey::Num(0),
+      JsonKey::Num(42),
+    ]));
+    assert!(json.matches_path(&[
+      JsonKey::String("mixed".to_string()),
+      JsonKey::Num(1),
+      JsonKey::String("string".to_string()),
+    ]));
+    assert!(json.matches_path(&[
+      JsonKey::String("mixed".to_string()),
+      JsonKey::Num(2),
+      JsonKey::String("key".to_string()),
+      JsonKey::String("value".to_string()),
+    ]));
+  }
+
+  #[test]
+  fn test_empty_string_keys_and_values() {
+    let json = notary_body!(
+        "": {
+            "empty": ""
+        }
+    );
+    // Test empty string keys and values
+    assert!(json.matches_path(&[
+      JsonKey::String("".to_string()),
+      JsonKey::String("empty".to_string()),
+      JsonKey::String("".to_string()),
+    ]));
+  }
+
+  #[test]
+  fn test_very_deep_nesting() {
+    // Test different depths: 3, 10, and 100 levels
+    let depths = vec![5, 25, 100];
+
+    for depth in depths {
+      // Build nested JSON structure
+      let mut json_value = serde_json::json!("value");
+      for i in (0..depth).rev() {
+        json_value = serde_json::json!({
+            format!("level{}", i): json_value
+        });
+      }
+
+      let json = NotaryResponseBody { json: Some(json_value) };
+
+      // Build the path
+      let mut path = Vec::new();
+      for i in 0..depth {
+        path.push(JsonKey::String(format!("level{}", i)));
+      }
+      path.push(JsonKey::String("value".to_string()));
+
+      // Test the path
+      let result = json.matches_path(&path);
+      assert!(result, "Failed to match path at depth {}: {:?}", depth, path);
+    }
   }
 }

--- a/proofs/src/program/http.rs
+++ b/proofs/src/program/http.rs
@@ -948,6 +948,7 @@ mod tests {
             }
         }
     );
+    // ["key1", "key2", "key3"]
     let mut path = vec![
       JsonKey::String("key1".to_string()),
       JsonKey::String("key2".to_string()),
@@ -955,11 +956,15 @@ mod tests {
     ];
     assert!(json.matches_path(&path));
 
-    path.push(JsonKey::String("value".to_string()));
-    assert!(json.matches_path(&path));
+    // ["key1", "key2", "key3", "value"]
+    let mut path_with_value = path.clone();
+    path_with_value.push(JsonKey::String("value".to_string()));
+    assert!(json.matches_path(&path_with_value));
 
-    path.push(JsonKey::String("invalid".to_string()));
-    assert!(!json.matches_path(&path));
+    // ["key1", "key2", "key3", "value", "invalid"]
+    let mut path_with_invalid_value = path.clone();
+    path_with_invalid_value.push(JsonKey::String("invalid_value".to_string()));
+    assert!(!json.matches_path(&path_with_invalid_value));
   }
 
   #[test]

--- a/proofs/src/tests/inputs.rs
+++ b/proofs/src/tests/inputs.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use web_proof_circuits_witness_generator::json::JsonKey;
 
 use crate::program::{
-  http::{ManifestRequest, ManifestResponse, ResponseBody},
+  http::{ManifestRequest, ManifestResponse, ManifestResponseBody},
   manifest::{EncryptionInput, Manifest},
 };
 
@@ -52,8 +52,7 @@ pub(crate) const TEST_MANIFEST: &str = r#"
         "body": {
             "json": [
                 "hello"
-            ],
-            "contains": "this_string_exists_in_body"
+            ]
         }
     }
 }
@@ -685,13 +684,12 @@ pub(crate) fn complex_manifest() -> Manifest {
         ("Date".to_string(), "Mon, 27 Jan 2025 10:15:31 GMT".to_string()),
         ("Server".to_string(), "nginx/1.18.0".to_string()),
       ]),
-      body:    ResponseBody {
-        json:        vec![
+      body:    ManifestResponseBody {
+        json_path: vec![
           JsonKey::String(String::from("data")),
           JsonKey::String(String::from("orderDetails")),
           JsonKey::String(String::from("orderId")),
         ],
-        json_actual: None,
       },
     },
   }


### PR DESCRIPTION
- Fixes #491 
- Introduces `NotaryResponse` and `NotaryResponseBody` to separate `ManifestResponse` and verification logic & parsing JSON
- `Manifest.body.json` now describes JSON path with an optional value matching
	- For n elements n>0, initial elements are treated as object keys and array indices, and element n+1 treated as a literal value
	- This offers a middle ground between adding another workaround for value matching/DSL, while being extendable enough to be retrofitted into a DSL without breaking changes
	- **Note: This is a breaking change** 
- Required reviews: 2