### PR TITLE
chore: Centralize dependencies into workspace `Cargo.toml`

### DIFF
--- a/.github/workflows/cargo-deps.yaml
+++ b/.github/workflows/cargo-deps.yaml
@@ -29,4 +29,15 @@ jobs:
             echo "Your dependencies are not centralized in the cargo workspace. Make sure to run `cargo autoinherit` and try again."
             exit 1
           fi
+      
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps
+        
+      - name: Check for unused dependencies
+        run: |
+          cargo udeps --workspace
+          if [ $? -ne 0 ]; then
+            echo "There are unused dependencies. Please clean up your Cargo.toml files."
+            exit 1
+          fi
 

--- a/.github/workflows/cargo-deps.yaml
+++ b/.github/workflows/cargo-deps.yaml
@@ -1,0 +1,32 @@
+name: Cargo Dependencies
+
+on:
+  workflow_call:
+    inputs:
+      web-prover-circuits-cache-key:
+        required: true
+        type: string
+
+jobs:
+  cargo-autoinherit:
+    continue-on-error: true
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-rust-ubuntu
+        with:
+          rust-cache-key: clippy # TODO: What do I put here? I don't need clippy, just cargo
+
+      - name: Install cargo-autoinherit
+        run: cargo install cargo-autoinherit
+
+      - name: Check if deps are inherited into workspace
+        run: |
+          cargo autoinherit
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Your dependencies are not centralized in the cargo workspace. Make sure to run `cargo autoinherit` and try again."
+            exit 1
+          fi
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3879,7 +3879,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-core",
- "base64 0.21.7",
+ "base64 0.22.1",
  "caratls_ekm_google_confidential_space_server",
  "caratls_ekm_server",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,60 @@ tokio-rustls={ version="0.26.0", default-features=false, features=["logging", "t
 web-proof-circuits-witness-generator={ git="https://github.com/pluto/web-prover-circuits", rev="0a09df087612d45fa3b0d5914d93c72417edb58b" }
 
 uuid={ version="1.10.0", default-features=false, features=["v4", "serde"] }
+alloy-primitives = "0.8.2"
+async-trait = "0.1.67"
+axum = "0.7"
+axum-core = "0.4"
+base64 = "0.22.1"
+bellpepper-core = "0.4"
+bincode = "1.3"
+byteorder = "1.5"
+bytes = "1"
+cargo_metadata = "0.19.1"
+chrono = "0.4"
+client-side-prover = { git = "https://github.com/pluto/client-side-prover", rev = "8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
+config = "0.14.0"
+console_error_panic_hook = "0.1.7"
+eyre = "0.6.8"
+ff = { version = "0.13", default-features = false }
+futures-util = "0.3.30"
+halo2curves = "0.6.1"
+hex = "0.4"
+http = "1.1"
+itertools = "0.13"
+js-sys = "0.3.64"
+k256 = "0.13.3"
+nom = "7.0"
+num-bigint = "0.4"
+p256 = "0.13"
+pki-types = "1.7"
+regex = "1.11.1"
+regress = "0.10.3"
+reqwest = "0.12"
+rs_merkle = "1.4.2"
+rustls = { version = "0.23.11", default-features = false }
+rustls-acme = { version = "0.10", default-features = false }
+rustls-pemfile = "2.1.2"
+serde-wasm-bindgen = "0.6.5"
+serde_with = "3.12.0"
+sha1 = "0.10"
+tempdir = "0.3.7"
+time = "0.3.34"
+tiny-keccak = "2.0.2"
+tls-parser = "0.12.0"
+tokio-stream = "0.1"
+tokio-tungstenite = "0.23.1"
+tower = "0.4.13"
+tower-http = "0.5.2"
+tower-service = "0.3.2"
+tracing-test = "0.2.5"
+tracing-web = "0.1.2"
+url = "2.5"
+wasm-bindgen = "=0.2.93"
+wasm-bindgen-futures = "=0.4.43"
+wasm-bindgen-test = "0.3.34"
+webpki-roots = "0.26.1"
+ws_stream_tungstenite = { git = "https://github.com/pluto/ws_stream_tungstenite.git", branch = "latest" }
 
 [package]
 name   ="webprover"
@@ -71,8 +125,8 @@ hyper         ={ workspace=true }
 hyper-util    ={ workspace=true }
 http-body-util={ workspace=true }
 pki-types     ={ package="rustls-pki-types", version="1.7" }
-rustls        ={ version="0.23.11", default-features=false, features=["logging", "tls12", "std", "ring"] }
-rustls-pemfile={ version="2.0.0" }
+rustls        ={ workspace = true, features = ["logging", "tls12", "std", "ring"] }
+rustls-pemfile={ workspace = true }
 tokio         ={ workspace=true }
 tokio-rustls  ={ workspace=true }
 serde_json    ={ workspace=true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,61 +54,61 @@ tokio-rustls={ version="0.26.0", default-features=false, features=["logging", "t
 # circuits witness generator
 web-proof-circuits-witness-generator={ git="https://github.com/pluto/web-prover-circuits", rev="0a09df087612d45fa3b0d5914d93c72417edb58b" }
 
-uuid={ version="1.10.0", default-features=false, features=["v4", "serde"] }
-alloy-primitives = "0.8.2"
-async-trait = "0.1.67"
-axum = "0.7"
-axum-core = "0.4"
-base64 = "0.22.1"
-bellpepper-core = "0.4"
-bincode = "1.3"
-byteorder = "1.5"
-bytes = "1"
-cargo_metadata = "0.19.1"
-chrono = "0.4"
-client-side-prover = { git = "https://github.com/pluto/client-side-prover", rev = "8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
-config = "0.14.0"
-console_error_panic_hook = "0.1.7"
-eyre = "0.6.8"
-ff = { version = "0.13", default-features = false }
-futures-util = "0.3.30"
-halo2curves = "0.6.1"
-hex = "0.4"
-http = "1.1"
-itertools = "0.13"
-js-sys = "0.3.64"
-k256 = "0.13.3"
-nom = "7.0"
-num-bigint = "0.4"
-p256 = "0.13"
-pki-types = "1.7"
-regex = "1.11.1"
-regress = "0.10.3"
-reqwest = "0.12"
-rs_merkle = "1.4.2"
-rustls = { version = "0.23.11", default-features = false }
-rustls-acme = { version = "0.10", default-features = false }
-rustls-pemfile = "2.1.2"
-serde-wasm-bindgen = "0.6.5"
-serde_with = "3.12.0"
-sha1 = "0.10"
-tempdir = "0.3.7"
-time = "0.3.34"
-tiny-keccak = "2.0.2"
-tls-parser = "0.12.0"
-tokio-stream = "0.1"
-tokio-tungstenite = "0.23.1"
-tower = "0.4.13"
-tower-http = "0.5.2"
-tower-service = "0.3.2"
-tracing-test = "0.2.5"
-tracing-web = "0.1.2"
-url = "2.5"
-wasm-bindgen = "=0.2.93"
-wasm-bindgen-futures = "=0.4.43"
-wasm-bindgen-test = "0.3.34"
-webpki-roots = "0.26.1"
-ws_stream_tungstenite = { git = "https://github.com/pluto/ws_stream_tungstenite.git", branch = "latest" }
+uuid                    ={ version="1.10.0", default-features=false, features=["v4", "serde"] }
+alloy-primitives        ="0.8.2"
+async-trait             ="0.1.67"
+axum                    ="0.7"
+axum-core               ="0.4"
+base64                  ="0.22.1"
+bellpepper-core         ="0.4"
+bincode                 ="1.3"
+byteorder               ="1.5"
+bytes                   ="1"
+cargo_metadata          ="0.19.1"
+chrono                  ="0.4"
+client-side-prover      ={ git="https://github.com/pluto/client-side-prover", rev="8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
+config                  ="0.14.0"
+console_error_panic_hook="0.1.7"
+eyre                    ="0.6.8"
+ff                      ={ version="0.13", default-features=false }
+futures-util            ="0.3.30"
+halo2curves             ="0.6.1"
+hex                     ="0.4"
+http                    ="1.1"
+itertools               ="0.13"
+js-sys                  ="0.3.64"
+k256                    ="0.13.3"
+nom                     ="7.0"
+num-bigint              ="0.4"
+p256                    ="0.13"
+pki-types               ="1.7"
+regex                   ="1.11.1"
+regress                 ="0.10.3"
+reqwest                 ="0.12"
+rs_merkle               ="1.4.2"
+rustls                  ={ version="0.23.11", default-features=false }
+rustls-acme             ={ version="0.10", default-features=false }
+rustls-pemfile          ="2.1.2"
+serde-wasm-bindgen      ="0.6.5"
+serde_with              ="3.12.0"
+sha1                    ="0.10"
+tempdir                 ="0.3.7"
+time                    ="0.3.34"
+tiny-keccak             ="2.0.2"
+tls-parser              ="0.12.0"
+tokio-stream            ="0.1"
+tokio-tungstenite       ="0.23.1"
+tower                   ="0.4.13"
+tower-http              ="0.5.2"
+tower-service           ="0.3.2"
+tracing-test            ="0.2.5"
+tracing-web             ="0.1.2"
+url                     ="2.5"
+wasm-bindgen            ="=0.2.93"
+wasm-bindgen-futures    ="=0.4.43"
+wasm-bindgen-test       ="0.3.34"
+webpki-roots            ="0.26.1"
+ws_stream_tungstenite   ={ git="https://github.com/pluto/ws_stream_tungstenite.git", branch="latest" }
 
 [package]
 name   ="webprover"
@@ -125,8 +125,8 @@ hyper         ={ workspace=true }
 hyper-util    ={ workspace=true }
 http-body-util={ workspace=true }
 pki-types     ={ package="rustls-pki-types", version="1.7" }
-rustls        ={ workspace = true, features = ["logging", "tls12", "std", "ring"] }
-rustls-pemfile={ workspace = true }
+rustls        ={ workspace=true, features=["logging", "tls12", "std", "ring"] }
+rustls-pemfile={ workspace=true }
 tokio         ={ workspace=true }
 tokio-rustls  ={ workspace=true }
 serde_json    ={ workspace=true }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,7 +18,7 @@ tee-dummy-token-verifier                    =[]
 tee-google-confidential-space-token-verifier=[]
 
 [build-dependencies]
-cargo_metadata="0.19.1"
+cargo_metadata={ workspace = true }
 
 # Shared dependencies for all targets
 [dependencies]
@@ -26,7 +26,7 @@ cargo_metadata="0.19.1"
 tls-client        ={ workspace=true }
 tls-client2       ={ workspace=true }
 tls-core          ={ workspace=true }
-client-side-prover={ git="https://github.com/pluto/client-side-prover", rev="8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
+client-side-prover={ workspace = true }
 
 # TLSN
 tlsn-prover={ workspace=true }
@@ -35,20 +35,20 @@ tlsn-core  ={ workspace=true }
 caratls_ekm_client                          ={ workspace=true }
 caratls_ekm_google_confidential_space_client={ workspace=true }
 
-bytes                               ="1"
+bytes                               ={ workspace = true }
 proofs                              ={ workspace=true }
 web-proof-circuits-witness-generator={ workspace=true }
 
-serde-wasm-bindgen="0.6.5"
+serde-wasm-bindgen={ workspace = true }
 
-webpki-roots="0.26.1"
+webpki-roots={ workspace = true }
 pki-types   ={ package="rustls-pki-types", version="1.7" }
 # Serde
 serde     ={ workspace=true }
 serde_json={ workspace=true }
 # Web
-hex           ="0.4"
-url           ="2.5"
+hex           ={ workspace = true }
+url           ={ workspace = true }
 hyper         ={ workspace=true, features=["client", "http1"] }
 http-body-util={ workspace=true }
 # Logging and errors
@@ -58,17 +58,15 @@ thiserror         ={ workspace=true }
 # Async
 futures={ workspace=true }
 # Other
-base64="0.22.0"
-tokio-util={ version="0.7", features=[
-  "compat",
-] } # compat is used to work with AsyncRead and AsyncWrite from other crates
-chrono="0.4"
-p256={ version="0.13", features=["pem", "ecdsa"] }
+base64={ workspace = true }
+tokio-util={ workspace = true, features = ["compat"] } # compat is used to work with AsyncRead and AsyncWrite from other crates
+chrono={ workspace = true }
+p256={ workspace = true, features = ["pem", "ecdsa"] }
 
 uuid={ workspace=true }
 
 clap      ={ workspace=true }
-serde_with={ version="3.12.0", features=["base64"] }
+serde_with={ workspace = true, features = ["base64"] }
 
 ####################################################################################################
 # Target-specific configuration

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -18,7 +18,7 @@ tee-dummy-token-verifier                    =[]
 tee-google-confidential-space-token-verifier=[]
 
 [build-dependencies]
-cargo_metadata={ workspace = true }
+cargo_metadata={ workspace=true }
 
 # Shared dependencies for all targets
 [dependencies]
@@ -26,7 +26,7 @@ cargo_metadata={ workspace = true }
 tls-client        ={ workspace=true }
 tls-client2       ={ workspace=true }
 tls-core          ={ workspace=true }
-client-side-prover={ workspace = true }
+client-side-prover={ workspace=true }
 
 # TLSN
 tlsn-prover={ workspace=true }
@@ -35,20 +35,20 @@ tlsn-core  ={ workspace=true }
 caratls_ekm_client                          ={ workspace=true }
 caratls_ekm_google_confidential_space_client={ workspace=true }
 
-bytes                               ={ workspace = true }
+bytes                               ={ workspace=true }
 proofs                              ={ workspace=true }
 web-proof-circuits-witness-generator={ workspace=true }
 
-serde-wasm-bindgen={ workspace = true }
+serde-wasm-bindgen={ workspace=true }
 
-webpki-roots={ workspace = true }
+webpki-roots={ workspace=true }
 pki-types   ={ package="rustls-pki-types", version="1.7" }
 # Serde
 serde     ={ workspace=true }
 serde_json={ workspace=true }
 # Web
-hex           ={ workspace = true }
-url           ={ workspace = true }
+hex           ={ workspace=true }
+url           ={ workspace=true }
 hyper         ={ workspace=true, features=["client", "http1"] }
 http-body-util={ workspace=true }
 # Logging and errors
@@ -58,15 +58,17 @@ thiserror         ={ workspace=true }
 # Async
 futures={ workspace=true }
 # Other
-base64={ workspace = true }
-tokio-util={ workspace = true, features = ["compat"] } # compat is used to work with AsyncRead and AsyncWrite from other crates
-chrono={ workspace = true }
-p256={ workspace = true, features = ["pem", "ecdsa"] }
+base64={ workspace=true }
+tokio-util={ workspace=true, features=[
+  "compat",
+] } # compat is used to work with AsyncRead and AsyncWrite from other crates
+chrono={ workspace=true }
+p256={ workspace=true, features=["pem", "ecdsa"] }
 
 uuid={ workspace=true }
 
 clap      ={ workspace=true }
-serde_with={ workspace = true, features = ["base64"] }
+serde_with={ workspace=true, features=["base64"] }
 
 ####################################################################################################
 # Target-specific configuration

--- a/client_ios/Cargo.toml
+++ b/client_ios/Cargo.toml
@@ -22,4 +22,4 @@ tokio ={ workspace=true }
 proofs={ workspace=true }
 
 [build-dependencies]
-cargo_metadata={ workspace = true }
+cargo_metadata={ workspace=true }

--- a/client_ios/Cargo.toml
+++ b/client_ios/Cargo.toml
@@ -22,4 +22,4 @@ tokio ={ workspace=true }
 proofs={ workspace=true }
 
 [build-dependencies]
-cargo_metadata="0.19.1"
+cargo_metadata={ workspace = true }

--- a/client_wasm/Cargo.toml
+++ b/client_wasm/Cargo.toml
@@ -10,20 +10,20 @@ crate-type=["cdylib", "rlib"]
 
 [dependencies]
 client              ={ workspace=true, features=["websocket"] }
-js-sys              ="0.3.64"
-serde-wasm-bindgen  ="0.6.1"
+js-sys              ={ workspace = true }
+serde-wasm-bindgen  ={ workspace = true }
 serde_json          ={ workspace=true }
 tracing             ={ workspace=true }
-wasm-bindgen        ="=0.2.93"
+wasm-bindgen        ={ workspace = true }
 wasm-bindgen-rayon  ={ workspace=true }
-wasm-bindgen-futures="=0.4.43"
+wasm-bindgen-futures={ workspace = true }
 tracing-subscriber  ={ workspace=true, features=["time"] }
-tracing-web         ="0.1.2"
+tracing-web         ={ workspace = true }
 
 # time crate: https://crates.io/crates/time
 # NOTE: It is required, otherwise "time not implemented on this platform" error happens right after "!@# 2".
 # Probably due to tokio's time feature is used in tlsn-prover?
-time     ={ version="0.3.34", features=["wasm-bindgen"] }
+time     ={ workspace = true, features = ["wasm-bindgen"] }
 tlsn-core={ workspace=true }
 
 # NOTE: Leacing this here in case we still need it for tlsn flow.
@@ -34,13 +34,13 @@ tlsn-core={ workspace=true }
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook={ version="0.1.7" }
+console_error_panic_hook={ workspace = true }
 
 [dev-dependencies]
-wasm-bindgen-test="0.3.34"
+wasm-bindgen-test={ workspace = true }
 
 [build-dependencies]
-cargo_metadata="0.19.1"
+cargo_metadata={ workspace = true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt=[

--- a/client_wasm/Cargo.toml
+++ b/client_wasm/Cargo.toml
@@ -10,20 +10,20 @@ crate-type=["cdylib", "rlib"]
 
 [dependencies]
 client              ={ workspace=true, features=["websocket"] }
-js-sys              ={ workspace = true }
-serde-wasm-bindgen  ={ workspace = true }
+js-sys              ={ workspace=true }
+serde-wasm-bindgen  ={ workspace=true }
 serde_json          ={ workspace=true }
 tracing             ={ workspace=true }
-wasm-bindgen        ={ workspace = true }
+wasm-bindgen        ={ workspace=true }
 wasm-bindgen-rayon  ={ workspace=true }
-wasm-bindgen-futures={ workspace = true }
+wasm-bindgen-futures={ workspace=true }
 tracing-subscriber  ={ workspace=true, features=["time"] }
-tracing-web         ={ workspace = true }
+tracing-web         ={ workspace=true }
 
 # time crate: https://crates.io/crates/time
 # NOTE: It is required, otherwise "time not implemented on this platform" error happens right after "!@# 2".
 # Probably due to tokio's time feature is used in tlsn-prover?
-time     ={ workspace = true, features = ["wasm-bindgen"] }
+time     ={ workspace=true, features=["wasm-bindgen"] }
 tlsn-core={ workspace=true }
 
 # NOTE: Leacing this here in case we still need it for tlsn flow.
@@ -34,13 +34,13 @@ tlsn-core={ workspace=true }
 # logging them with `console.error`. This is great for development, but requires
 # all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
 # code size when deploying.
-console_error_panic_hook={ workspace = true }
+console_error_panic_hook={ workspace=true }
 
 [dev-dependencies]
-wasm-bindgen-test={ workspace = true }
+wasm-bindgen-test={ workspace=true }
 
 [build-dependencies]
-cargo_metadata={ workspace = true }
+cargo_metadata={ workspace=true }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt=[

--- a/notary/Cargo.toml
+++ b/notary/Cargo.toml
@@ -10,50 +10,48 @@ tee-dummy-token-generator                    =[]
 tee-google-confidential-space-token-generator=[]
 
 [dependencies]
-client-side-prover={ git="https://github.com/pluto/client-side-prover", rev="8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
-proofs={ path="../proofs", package="proofs" }
-client={ path="../client", package="client" }
+client-side-prover={ workspace = true }
+proofs={ workspace = true }
+client={ workspace = true }
 hyper={ workspace=true, features=["client", "http1", "server"] }
 hyper-util={ workspace=true }
 serde={ workspace=true }
 serde_json={ workspace=true }
-rustls={ version="0.23.11", default-features=false, features=["logging", "tls12", "std", "ring"] }
+rustls={ workspace = true, features = ["logging", "tls12", "std", "ring"] }
 tokio={ workspace=true }
 tokio-util={ workspace=true, features=["compat"] }
 tracing={ workspace=true }
 tracing-subscriber={ workspace=true }
 futures={ workspace=true }
-futures-util="0.3.30"
+futures-util={ workspace = true }
 tokio-rustls={ workspace=true, features=["ring"] }
-tower-http={ version="0.5.2", features=["cors"] }
-tower-service="0.3.2"
-rustls-pemfile="2.1.2"
+tower-http={ workspace = true, features = ["cors"] }
+tower-service={ workspace = true }
+rustls-pemfile={ workspace = true }
 tlsn-verifier={ workspace=true }
-tokio-tungstenite={ version="0.23.1", features=["stream"] }
-ws_stream_tungstenite={ git="https://github.com/pluto/ws_stream_tungstenite.git", branch="latest", features=[
-  "tokio",
-] }
-nom="7.0"
+tokio-tungstenite={ workspace = true, features = ["stream"] }
+ws_stream_tungstenite={ workspace = true, features = ["tokio"] }
+nom={ workspace = true }
 
-async-trait     ="0.1.67"
-axum            ={ version="0.7", features=["ws", "json"] }
-axum-core       ="0.4"
-eyre            ="0.6.8"
-p256            ="0.13"
-base64          ="0.21.0"
-http            ="1.1"
-sha1            ="0.10"
-config          ="0.14.0"
+async-trait     ={ workspace = true }
+axum            ={ workspace = true, features = ["ws", "json"] }
+axum-core       ={ workspace = true }
+eyre            ={ workspace = true }
+p256            ={ workspace = true }
+base64          ={ workspace = true }
+http            ={ workspace = true }
+sha1            ={ workspace = true }
+config          ={ workspace = true }
 clap            ={ workspace=true }
-rustls-acme     ={ version="0.10", default-features=false, features=["ring", "tokio"] }
-tokio-stream    ={ version="0.1", features=["net"] }
+rustls-acme     ={ workspace = true, features = ["ring", "tokio"] }
+tokio-stream    ={ workspace = true, features = ["net"] }
 thiserror       ={ workspace=true }
-hex             ="0.4"
-tls-parser      ="0.12.0"
-rs_merkle       ="1.4.2"
-alloy-primitives={ version="0.8.2", features=["k256"] }
-k256            ={ version="0.13.3", features=["ecdsa"] }
-reqwest         ={ version="0.12", features=["json"] }
+hex             ={ workspace = true }
+tls-parser      ={ workspace = true }
+rs_merkle       ={ workspace = true }
+alloy-primitives={ workspace = true, features = ["k256"] }
+k256            ={ workspace = true, features = ["ecdsa"] }
+reqwest         ={ workspace = true, features = ["json"] }
 uuid            ={ workspace=true }
 
 tls-client2={ workspace=true }
@@ -63,7 +61,7 @@ caratls_ekm_google_confidential_space_server={ workspace=true }
 web-proof-circuits-witness-generator        ={ workspace=true }
 
 [dev-dependencies]
-tower="0.4.13"
+tower={ workspace = true }
 
 [build-dependencies]
-cargo_metadata="0.19.1"
+cargo_metadata={ workspace = true }

--- a/notary/Cargo.toml
+++ b/notary/Cargo.toml
@@ -10,48 +10,48 @@ tee-dummy-token-generator                    =[]
 tee-google-confidential-space-token-generator=[]
 
 [dependencies]
-client-side-prover={ workspace = true }
-proofs={ workspace = true }
-client={ workspace = true }
-hyper={ workspace=true, features=["client", "http1", "server"] }
-hyper-util={ workspace=true }
-serde={ workspace=true }
-serde_json={ workspace=true }
-rustls={ workspace = true, features = ["logging", "tls12", "std", "ring"] }
-tokio={ workspace=true }
-tokio-util={ workspace=true, features=["compat"] }
-tracing={ workspace=true }
-tracing-subscriber={ workspace=true }
-futures={ workspace=true }
-futures-util={ workspace = true }
-tokio-rustls={ workspace=true, features=["ring"] }
-tower-http={ workspace = true, features = ["cors"] }
-tower-service={ workspace = true }
-rustls-pemfile={ workspace = true }
-tlsn-verifier={ workspace=true }
-tokio-tungstenite={ workspace = true, features = ["stream"] }
-ws_stream_tungstenite={ workspace = true, features = ["tokio"] }
-nom={ workspace = true }
+client-side-prover   ={ workspace=true }
+proofs               ={ workspace=true }
+client               ={ workspace=true }
+hyper                ={ workspace=true, features=["client", "http1", "server"] }
+hyper-util           ={ workspace=true }
+serde                ={ workspace=true }
+serde_json           ={ workspace=true }
+rustls               ={ workspace=true, features=["logging", "tls12", "std", "ring"] }
+tokio                ={ workspace=true }
+tokio-util           ={ workspace=true, features=["compat"] }
+tracing              ={ workspace=true }
+tracing-subscriber   ={ workspace=true }
+futures              ={ workspace=true }
+futures-util         ={ workspace=true }
+tokio-rustls         ={ workspace=true, features=["ring"] }
+tower-http           ={ workspace=true, features=["cors"] }
+tower-service        ={ workspace=true }
+rustls-pemfile       ={ workspace=true }
+tlsn-verifier        ={ workspace=true }
+tokio-tungstenite    ={ workspace=true, features=["stream"] }
+ws_stream_tungstenite={ workspace=true, features=["tokio"] }
+nom                  ={ workspace=true }
 
-async-trait     ={ workspace = true }
-axum            ={ workspace = true, features = ["ws", "json"] }
-axum-core       ={ workspace = true }
-eyre            ={ workspace = true }
-p256            ={ workspace = true }
-base64          ={ workspace = true }
-http            ={ workspace = true }
-sha1            ={ workspace = true }
-config          ={ workspace = true }
+async-trait     ={ workspace=true }
+axum            ={ workspace=true, features=["ws", "json"] }
+axum-core       ={ workspace=true }
+eyre            ={ workspace=true }
+p256            ={ workspace=true }
+base64          ={ workspace=true }
+http            ={ workspace=true }
+sha1            ={ workspace=true }
+config          ={ workspace=true }
 clap            ={ workspace=true }
-rustls-acme     ={ workspace = true, features = ["ring", "tokio"] }
-tokio-stream    ={ workspace = true, features = ["net"] }
+rustls-acme     ={ workspace=true, features=["ring", "tokio"] }
+tokio-stream    ={ workspace=true, features=["net"] }
 thiserror       ={ workspace=true }
-hex             ={ workspace = true }
-tls-parser      ={ workspace = true }
-rs_merkle       ={ workspace = true }
-alloy-primitives={ workspace = true, features = ["k256"] }
-k256            ={ workspace = true, features = ["ecdsa"] }
-reqwest         ={ workspace = true, features = ["json"] }
+hex             ={ workspace=true }
+tls-parser      ={ workspace=true }
+rs_merkle       ={ workspace=true }
+alloy-primitives={ workspace=true, features=["k256"] }
+k256            ={ workspace=true, features=["ecdsa"] }
+reqwest         ={ workspace=true, features=["json"] }
 uuid            ={ workspace=true }
 
 tls-client2={ workspace=true }
@@ -61,7 +61,7 @@ caratls_ekm_google_confidential_space_server={ workspace=true }
 web-proof-circuits-witness-generator        ={ workspace=true }
 
 [dev-dependencies]
-tower={ workspace = true }
+tower={ workspace=true }
 
 [build-dependencies]
-cargo_metadata={ workspace = true }
+cargo_metadata={ workspace=true }

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -12,25 +12,25 @@ thiserror  ={ workspace=true }
 tracing    ={ workspace=true }
 tls-client2={ workspace=true } # a bit of an odd dependency to have in here imo
 
-hex                                 ={ workspace = true }
-client-side-prover                  ={ workspace = true }
-ff                                  ={ workspace = true, features = ["derive"] }
-bellpepper-core                     ={ workspace = true }
-halo2curves                         ={ workspace = true }
-url                                 ={ workspace = true }
+hex                                 ={ workspace=true }
+client-side-prover                  ={ workspace=true }
+ff                                  ={ workspace=true, features=["derive"] }
+bellpepper-core                     ={ workspace=true }
+halo2curves                         ={ workspace=true }
+url                                 ={ workspace=true }
 web-proof-circuits-witness-generator={ workspace=true }
 
-byteorder ={ workspace = true }
-num-bigint={ workspace = true }
-itertools ={ workspace = true }
+byteorder ={ workspace=true }
+num-bigint={ workspace=true }
+itertools ={ workspace=true }
 
-bincode={ workspace = true }
+bincode={ workspace=true }
 
-tokio={ workspace = true, features = ["rt", "macros"] }
+tokio={ workspace=true, features=["rt", "macros"] }
 # Using `regress` crate for compatibility with ECMAScript regular expressions in Manifest validation
-regress    ={ workspace = true }
-regex      ={ workspace = true }
-tiny-keccak={ workspace = true, features = ["keccak"] }
+regress    ={ workspace=true }
+regex      ={ workspace=true }
+tiny-keccak={ workspace=true, features=["keccak"] }
 
 #- Wasm target configuration ----------------------------------------------------------------------#
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -43,11 +43,11 @@ wasm-bindgen-futures="0.4.37"
 circom_witnesscalc={ git="https://github.com/pluto/circom-witnesscalc" } # Fork is needed apparently??
 
 [dev-dependencies]
-tracing-test={ workspace = true }
-tempdir     ={ workspace = true }
+tracing-test={ workspace=true }
+tempdir     ={ workspace=true }
 
 [build-dependencies]
-cargo_metadata={ workspace = true }
+cargo_metadata={ workspace=true }
 
 [features]
 verify-steps=[]

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -12,25 +12,25 @@ thiserror  ={ workspace=true }
 tracing    ={ workspace=true }
 tls-client2={ workspace=true } # a bit of an odd dependency to have in here imo
 
-hex                                 ="0.4"
-client-side-prover                  ={ git="https://github.com/pluto/client-side-prover", rev="8e7eb839e901dcee416179116bb0f9c4f7ae683c" }
-ff                                  ={ version="0.13", default-features=false, features=["derive"] }
-bellpepper-core                     ="0.4"
-halo2curves                         ="0.6.1"
-url                                 ="2.5"
+hex                                 ={ workspace = true }
+client-side-prover                  ={ workspace = true }
+ff                                  ={ workspace = true, features = ["derive"] }
+bellpepper-core                     ={ workspace = true }
+halo2curves                         ={ workspace = true }
+url                                 ={ workspace = true }
 web-proof-circuits-witness-generator={ workspace=true }
 
-byteorder ="1.5"
-num-bigint="0.4"
-itertools ="0.13"
+byteorder ={ workspace = true }
+num-bigint={ workspace = true }
+itertools ={ workspace = true }
 
-bincode="1.3"
+bincode={ workspace = true }
 
-tokio={ version="1.39.1", features=["rt", "macros"] }
+tokio={ workspace = true, features = ["rt", "macros"] }
 # Using `regress` crate for compatibility with ECMAScript regular expressions in Manifest validation
-regress    ="0.10.3"
-regex      ="1.11.1"
-tiny-keccak={ version="2.0.2", features=["keccak"] }
+regress    ={ workspace = true }
+regex      ={ workspace = true }
+tiny-keccak={ workspace = true, features = ["keccak"] }
 
 #- Wasm target configuration ----------------------------------------------------------------------#
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -43,11 +43,11 @@ wasm-bindgen-futures="0.4.37"
 circom_witnesscalc={ git="https://github.com/pluto/circom-witnesscalc" } # Fork is needed apparently??
 
 [dev-dependencies]
-tracing-test="0.2.5"
-tempdir     ="0.3.7"
+tracing-test={ workspace = true }
+tempdir     ={ workspace = true }
 
 [build-dependencies]
-cargo_metadata="0.19.1"
+cargo_metadata={ workspace = true }
 
 [features]
 verify-steps=[]


### PR DESCRIPTION
- Fixes: #492 
- [x] Add `cargo-udeps`
- Blocked by https://github.com/seanmonstar/reqwest/issues/1300