### PR TITLE
fix(origo): tls chunk decryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6140,7 +6140,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "tls-client"
 version = "0.1.0-alpha.5"
-source = "git+https://github.com/pluto/tls-origo-legacy#53657fa08d87b9b15b3578d769d5265b8548afcc"
+source = "git+https://github.com/pluto/tls-origo-legacy#47e4c30425aff40c0f081a7e718c17491a308d8b"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6171,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "tls-core"
 version = "0.0.0"
-source = "git+https://github.com/pluto/tls-origo-legacy#53657fa08d87b9b15b3578d769d5265b8548afcc"
+source = "git+https://github.com/pluto/tls-origo-legacy#47e4c30425aff40c0f081a7e718c17491a308d8b"
 dependencies = [
  "futures",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ serde_json    ={ workspace=true }
 
 [profile.dev]
 opt-level      =1
-overflow-checks=false
 split-debuginfo="unpacked"
 incremental    =true
 

--- a/client/src/tls.rs
+++ b/client/src/tls.rs
@@ -193,6 +193,8 @@ pub(crate) fn decrypt_tls_ciphertext(witness: &WitnessData) -> Result<TLSEncrypt
     .into_iter()
     .unzip();
 
+  // TODO (sambhav): seq is set assuming that server won't change session keys in between req/res
+  // sessions. Should revisit.
   Ok(TLSEncryption {
     request:  EncryptionInput {
       key:        request_key,

--- a/client/src/tls.rs
+++ b/client/src/tls.rs
@@ -1,6 +1,9 @@
 // TODO many root_stores ... this could use some cleanup where possible
 use proofs::program::manifest::{EncryptionInput, TLSEncryption};
-use tls_client2::{origo::WitnessData, CipherSuite, CipherSuiteKey, Decrypter, ProtocolVersion};
+use tls_client2::{
+  origo::{DecryptChunk, WitnessData},
+  CipherSuite, CipherSuiteKey, Decrypter, ProtocolVersion,
+};
 use tls_core::msgs::{base::Payload, enums::ContentType, message::OpaqueMessage};
 use tracing::debug;
 
@@ -95,17 +98,6 @@ pub fn tls_client_default_root_store(
 
 /// Decrypt plaintext from TLS transcript ciphertext using [`WitnessData`]
 pub(crate) fn decrypt_tls_ciphertext(witness: &WitnessData) -> Result<TLSEncryption, ClientErrors> {
-  // Request Preparation
-  let request_key = parse_cipher_key(&witness.request.aead_key)?;
-  let request_iv: [u8; 12] = witness.request.aead_iv[..12].try_into()?;
-  let request_seq = 0;
-  let request_ct = hex::decode(witness.request.ciphertext[0].as_bytes())?;
-  let request_pt = decrypt_chunk(&request_ct, &request_key, request_iv, request_seq)?;
-  let trim_bytes: usize = (TLS_13_TYPE_BYTES + TLS_13_AEAD_BYTES) as usize;
-
-  let mut padded_aad = vec![0; 16 - request_pt.aad.len()];
-  padded_aad.extend(request_pt.aad);
-
   // DEBUG: Use this test case to pin the ciphertext, you must also update
   // `src/notary/origo.rs#verify`.
   //
@@ -125,30 +117,56 @@ pub(crate) fn decrypt_tls_ciphertext(witness: &WitnessData) -> Result<TLSEncrypt
   //   "2c7db2"
   // )).unwrap();
 
-  // TODO (Sambhav): might have to apply similar multi-packet logic for request as well
-  // for now, only support a single request chunk.
-  let request_plaintext = vec![request_pt.plaintext];
-  let request_ciphertext = vec![request_ct[..request_plaintext[0].len()].to_vec()];
-  assert_eq!(request_plaintext[0].len(), request_ciphertext[0].len());
-  debug!("TLS_DECRYPT (request): plaintext={:?}", bytes_to_ascii(request_plaintext[0].clone()));
-  debug!("TLS_DECRYPT (request): ciphertext={:?}", hex::encode(request_ciphertext[0].clone()));
-  debug!(
-    "TLS_DECRYPT (request): trimmed_bytes={:?}",
-    hex::encode(&request_ciphertext[0].clone()[request_ciphertext[0].len() - trim_bytes..])
-  );
+  let trim_bytes: usize = (TLS_13_TYPE_BYTES + TLS_13_AEAD_BYTES) as usize;
+
+  // Request Preparation
+  let request_key = parse_cipher_key(&witness.request.aead_key)?;
+  let request_iv: [u8; 12] = witness.request.aead_iv[..12].try_into()?;
+  let (request_ciphertext, request_plaintext): (Vec<_>, Vec<_>) = witness
+    .request
+    .decrypt_chunk
+    .iter()
+    .enumerate()
+    .map(|(i, DecryptChunk { ciphertext: ct_chunk, seq })| {
+      let ct_chunk = hex::decode(ct_chunk)?;
+      let pt_chunk = decrypt_chunk(&ct_chunk, &request_key, request_iv, *seq)?;
+
+      debug!(
+        "TLS_DECRYPT (request, chunk={:?}): plaintext={:?}",
+        i,
+        bytes_to_ascii(pt_chunk.plaintext.clone())
+      );
+      debug!(
+        "TLS_DECRYPT (request, chunk={:?}): ciphertext={:?}",
+        i,
+        hex::encode(ct_chunk.clone())
+      );
+      debug!(
+        "TLS_DECRYPT (request, chunk={:?}): trimmed_bytes={:?}",
+        i,
+        hex::encode(&ct_chunk.clone()[ct_chunk.len() - trim_bytes..])
+      );
+
+      Ok::<(Vec<u8>, Vec<u8>), ClientErrors>((
+        ct_chunk[..pt_chunk.plaintext.len()].to_vec(),
+        pt_chunk.plaintext,
+      ))
+    })
+    .collect::<Result<Vec<_>, _>>()?
+    .into_iter()
+    .unzip();
 
   // Response Preparation
   let response_key = parse_cipher_key(&witness.response.aead_key)?;
   let response_iv: [u8; 12] = witness.response.aead_iv[..12].try_into()?;
-  let response_seq = request_seq + request_plaintext.len() as u64;
   let (response_ciphertext, response_plaintext): (Vec<_>, Vec<_>) = witness
     .response
-    .ciphertext
+    .decrypt_chunk
     .iter()
     .enumerate()
-    .map(|(i, ct_chunk)| {
+    .map(|(i, DecryptChunk { ciphertext: ct_chunk, seq })| {
       let ct_chunk = hex::decode(ct_chunk)?;
-      let pt_chunk = decrypt_chunk(&ct_chunk, &response_key, response_iv, i as u64 + response_seq)?;
+      let pt_chunk = decrypt_chunk(&ct_chunk, &response_key, response_iv, *seq)?;
 
       debug!(
         "TLS_DECRYPT (response, chunk={:?}): plaintext={:?}",
@@ -179,18 +197,18 @@ pub(crate) fn decrypt_tls_ciphertext(witness: &WitnessData) -> Result<TLSEncrypt
     request:  EncryptionInput {
       key:        request_key,
       iv:         request_iv,
-      aad:        padded_aad.clone(),
+      aad:        vec![0; TLS_13_AEAD_BYTES as usize],
       plaintext:  request_plaintext,
       ciphertext: request_ciphertext,
-      seq:        request_seq,
+      seq:        witness.request.decrypt_chunk[0].seq,
     },
     response: EncryptionInput {
       key:        response_key,
       iv:         response_iv,
-      aad:        padded_aad, // TODO: use response's AAD
+      aad:        vec![0; TLS_13_AEAD_BYTES as usize],
       plaintext:  response_plaintext,
       ciphertext: response_ciphertext,
-      seq:        response_seq,
+      seq:        witness.response.decrypt_chunk[0].seq,
     },
   })
 }

--- a/fixture/client.origo_tcp_local.json
+++ b/fixture/client.origo_tcp_local.json
@@ -4,7 +4,7 @@
 	"notary_port": 7443,
 	"notary_ca_cert": "MIIFszCCA5ugAwIBAgIUeXLQmnjeXsHpGji7xA8oJjjw7WwwDQYJKoZIhvcNAQELBQAwaTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExEjAQBgNVBAcMCVBhbG8gQWx0bzEVMBMGA1UECgwMT3JnYW5pemF0aW9uMRowGAYDVQQDDBFMb2NhbGhvc3QgUm9vdCBDQTAeFw0yNDA2MDcyMjUyNDBaFw0yOTA2MDYyMjUyNDBaMGkxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRIwEAYDVQQHDAlQYWxvIEFsdG8xFTATBgNVBAoMDE9yZ2FuaXphdGlvbjEaMBgGA1UEAwwRTG9jYWxob3N0IFJvb3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDIHMEL9gVSxT/J0qS4xDkDZs1d1UG0+z6NFLLsGdV7gu0ZJbDPlNd0kpjWsisVNB7TcqWoq5ROK5CR+6lZxXC8nbqr2YAJ2O8mHIXcYv7msAN3UYxtM6v1M7K+vNMJdDjZVAxcOKq5R7uUDUPw1weePz6eVEjntAW8mUjqkfnCqYml943Ud3724SkI5wyUT9rKS3bk6hvneq1ah/b1zRGDF2gp+T/oNe4ieS/LGoIUluE2csGRXtt542gpJnw5L54JASmGgt6hunUSWtoaht7Qxv6hYpieu4iHqZY1kfcFDjDH2WI16g1YqrWHzk1l7vWNLVDEcK3kdSQ1GmYAij8ZjAi0LJizLwtN//EkfxiOPlV435itK3uugY+etxrk77BeA6PmVcpZeLLXYuKSrzfaBh0ifP2p0uRlShURi5Rz4IE0I7wHkZ44x9MKYv8YzXK7O29HD158tgorxqwwKmkHqSxWpp7SRKvNnMulHN/el+IKDrPeBhVXsSSkd6U+/H61q7i0SY9TqqhdiMQLW/efK9LkVRen5myhwqogwiF/42Jp2nrCeuzv5YDsAFSrQ0lukW+Hz7FXV+0axnKeXZ08Nd+IS1BhGyMgHo6PWMP1fWyfO0DJVUfIqrHqvBy8bW0yNOuhiyU2oeyDRKv75OMxpIrUeX3qvmrVcYUPvfXsVQIDAQABo1MwUTAdBgNVHQ4EFgQUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wHwYDVR0jBBgwFoAUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEARliSCLdjNI5fFkNwXDK6k6jN5hITrY07XIawUIEwinjQqgLkYFvzXbMtfLwsWmxMPjDVYYDa5Y2NAGcH08b//2z9EuHxMOTOFTKr59BEcVxV1cxV+lspAunH8DLSlLJhf/EeR+MhIIHAfhlE8V7lvlE1EbM+Uj5JYIeefV/4omsGrphyHD3oSJAQDae0su200I/i2yAaTrwXLZ4HtaXsnxKZ4PMPFWaLvMQ8DsLgx2VB3/vQJn74Xepau6mYEWlRnUu90mj79gJOnwBKPlLojF6dJOMIJ2YHr9fI8sUfkVwPFVlkDKJcr0ll5RL3O/naNlLQZuOgijOM5YF5iTrefliVodEHpBPID2mhtq/E+ZIQWLpik8ulsJ8ufN9YfrbjbsiC/KeoMqoFCImRSyMGQDMADo4EV3DNfDFvfrHx0qBMmJ0nkhuGobphegMPCjZ3axvQwQulKuHXmFpAvGYcpK/twBMC1MJkV04tIwVEDZG6id5oKYtrIXHdSFshf6r3z4bbgq6kJnOxZ8Vo4cEw/dgc3hRivr+HnxOJcEk2CTQlCVOiCQAg64OqDEOoswVg6nzoO3RJhFatu+abO22MIXPNGma02zBoQZLYpGzL9z6pMnPKjL15G9H1SYVSTGhmq+GVtdRibg8rLBciSm3ERd7gNRqvYP5GrjCtUIbOTEc=",
 	"target_method": "GET",
-	"target_url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
+	"target_url": "https://www.apple.com/shop/experience-meta",
 	"target_headers": {},
 	"target_body": "",
 	"max_sent_data": 10000,
@@ -19,7 +19,7 @@
 			"request": {
 				"method": "GET",
 				"version": "HTTP/1.1",
-				"url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
+				"url": "https://www.apple.com/shop/experience-meta",
 				"headers": {
 					"accept-encoding": "identity"
 				},
@@ -41,11 +41,12 @@
 				"version": "HTTP/1.1",
 				"message": "OK",
 				"headers": {
-					"Content-Type": "text/plain; charset=utf-8"
+					"Content-Type": "application/json"
 				},
 				"body": {
 					"json": [
-						"hello"
+						"head",
+						"status"
 					],
 					"contains": "this_string_exists_in_body"
 				}


### PR DESCRIPTION
blocked by https://github.com/pluto/tls-origo-legacy/pull/2

closes #504 

---

We were not handling seq from tls chunks properly, and setting them based on assumption. Some servers can send arbitrary session key change request, that can change seq.

Example #504:
after client has sent the request with seq: 0
servers sends 2 session key change request: seq: 0,1
then sends response application data: seq: 2

- fixes ciphertext decryption logic using correct seq
- fixes notary ciphertext digest computation logic (checks every first ciphertext chunks)

TODO:
- fix `seq` in manifest
  - Currently, we're assuming that server won't change session key between the packets, i.e. once it starts sending the actual response, the session keys will remain same. 
  - But that isn't true, and server has the ability to change session keys anytime during the session.
- allow for arbitrary `ciphertext_digest` permutation logic in notary