### PR TITLE
chore: upgrade to 2024 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,10 +3288,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -7168,24 +7169,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -7194,21 +7195,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7216,9 +7218,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7241,9 +7243,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-bindgen-test"
@@ -7302,9 +7307,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 members=["client", "client_ios", "client_wasm", "notary", "proofs"]
 # members =["client", "client_wasm", "proofs"] # config for wasm32 rust analyzer
 # members =["client", "client_ios"] # config for ios rust analyzer
-resolver="2"
+package.edition="2024"
+resolver       ="2"
 
 [workspace.metadata]
 # https://github.com/pluto/web-prover-circuits/releases

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name   ="client"
-version="0.5.0"
-edition="2021"
-build  ="build.rs"
-publish=false
+name             ="client"
+version          ="0.5.0"
+build            ="build.rs"
+publish          =false
+edition.workspace=true
 
 [features]
 default=["tee-dummy-token-verifier"]

--- a/client/src/origo.rs
+++ b/client/src/origo.rs
@@ -252,10 +252,10 @@ mod tests {
   fn test_manifest_serialization() {
     let mut origo_conn = OrigoConnection::new();
     origo_conn.secret_map.insert("Handshake:server_iv".to_string(), vec![1, 2, 3]);
-    let origo_secrets = OrigoSecrets::from_origo_conn(&origo_conn);
+    let origo_secrets = &OrigoSecrets::from_origo_conn(&origo_conn);
 
     let serialized: Vec<u8> = origo_secrets.try_into().unwrap();
-    let deserialized: OrigoSecrets = OrigoSecrets::try_from(&serialized).unwrap();
-    assert_eq!(origo_secrets, deserialized);
+    let deserialized: OrigoSecrets = OrigoSecrets::try_from(serialized.as_ref()).unwrap();
+    assert_eq!(*origo_secrets, deserialized);
   }
 }

--- a/client/src/tls_client_async2/mod.rs
+++ b/client/src/tls_client_async2/mod.rs
@@ -192,7 +192,7 @@ pub fn bind_client<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
           // If we receive None from `TlsConnection`, it has closed, so we
           // send a close_notify to the server.
           data = &mut tx_recv_fut => {
-              if let Some(data) = data {
+              match data { Some(data) => {
                   debug!("writing {} plaintext bytes to client", data.len());
 
                   sent.extend(&data);
@@ -201,7 +201,7 @@ pub fn bind_client<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
                       .await?;
 
                   tx_recv_fut = tx_receiver.next().fuse();
-              } else {
+              } _ => {
                   if !server_closed {
                       if let Err(e) = send_close_notify(&mut client, &mut server_tx).await {
                           warn!("failed to send close_notify to server: {}", e);
@@ -211,7 +211,7 @@ pub fn bind_client<T: AsyncRead + AsyncWrite + Send + Unpin + 'static>(
                   trace!("closing client and terminating receiving end.");
                   client_closed = true;
                   tx_recv_fut = Fuse::terminated();
-              }
+              }}
           }
           // Waits for a notification from the backend that it is ready to decrypt data.
           _ = &mut notify => {

--- a/client_ios/Cargo.toml
+++ b/client_ios/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name   ="client_ios"
-version="0.5.0"
-edition="2021"
-build  ="build.rs"
-publish=false
+name             ="client_ios"
+version          ="0.5.0"
+build            ="build.rs"
+publish          =false
+edition.workspace=true
 
 [lib]
 crate-type=["staticlib"]

--- a/client_wasm/Cargo.toml
+++ b/client_wasm/Cargo.toml
@@ -10,13 +10,13 @@ crate-type=["cdylib", "rlib"]
 
 [dependencies]
 client              ={ workspace=true, features=["websocket"] }
-js-sys              ="0.3.64"
-serde-wasm-bindgen  ="0.6.1"
+js-sys              ="0.3.77"
+serde-wasm-bindgen  ="0.6.5"
 serde_json          ={ workspace=true }
 tracing             ={ workspace=true }
-wasm-bindgen        ="=0.2.93"
+wasm-bindgen        ="=0.2.100"
 wasm-bindgen-rayon  ={ workspace=true }
-wasm-bindgen-futures="=0.4.43"
+wasm-bindgen-futures="=0.4.50"
 tracing-subscriber  ={ workspace=true, features=["time"] }
 tracing-web         ="0.1.2"
 

--- a/notary/Cargo.toml
+++ b/notary/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name   ="notary"
-version="0.5.0"
-edition="2021"
-build  ="build.rs"
+name             ="notary"
+version          ="0.5.0"
+build            ="build.rs"
+edition.workspace=true
 
 [features]
 default                                      =["tee-dummy-token-generator"]

--- a/notary/src/axum_websocket.rs
+++ b/notary/src/axum_websocket.rs
@@ -457,11 +457,11 @@ where S: Send + Sync
 }
 
 fn header_contains(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {
-  let header = if let Some(header) = headers.get(&key) {
+  let header = match headers.get(&key) { Some(header) => {
     header
-  } else {
+  } _ => {
     return false;
-  };
+  }};
 
   if let Ok(header) = std::str::from_utf8(header.as_bytes()) {
     header.to_ascii_lowercase().contains(value)

--- a/notary/src/tcp.rs
+++ b/notary/src/tcp.rs
@@ -75,9 +75,9 @@ impl TcpUpgrade {
 }
 
 pub fn header_eq(headers: &HeaderMap, key: HeaderName, value: &'static str) -> bool {
-  if let Some(header) = headers.get(&key) {
+  match headers.get(&key) { Some(header) => {
     header.as_bytes().eq_ignore_ascii_case(value.as_bytes())
-  } else {
+  } _ => {
     false
-  }
+  }}
 }

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name   ="proofs"
-version="0.5.0"
-edition="2021"
-publish=false
-build  ="build.rs"
+name             ="proofs"
+version          ="0.5.0"
+publish          =false
+build            ="build.rs"
+edition.workspace=true
 
 [dependencies]
 serde      ={ workspace=true }

--- a/proofs/src/circom/wasm_witness.rs
+++ b/proofs/src/circom/wasm_witness.rs
@@ -14,7 +14,7 @@ impl WitnessOutput {
 }
 
 #[wasm_bindgen]
-extern "C" {
+unsafe extern "C" {
   #[wasm_bindgen(js_namespace = witness, js_name = createWitness)]
   async fn create_witness_js(input: &JsValue, opcode: u64) -> JsValue;
 }
@@ -23,7 +23,6 @@ extern "C" {
 pub async fn create_witness(input: JsValue, opcode: u64) -> Result<WitnessOutput, JsValue> {
   // Convert the Rust WitnessInput to a JsValue
   let js_witnesses_output = create_witness_js(&input, opcode).await;
-
   // Call JavaScript function and await the Promise
   info!("result: {:?}", js_witnesses_output);
   let js_obj = js_sys::Object::from(js_witnesses_output);

--- a/proofs/src/program/http.rs
+++ b/proofs/src/program/http.rs
@@ -449,7 +449,7 @@ pub(crate) mod tests {
   /// Creates a new HTTP request with optional parameters.
   macro_rules! create_request {
     // Match with optional parameters
-    ($($key:ident: $value:expr),* $(,)?) => {{
+    ($($key:ident: $value:expr_2021),* $(,)?) => {{
         let mut request = ManifestRequest {
             method: "GET".to_string(),
             url: "https://example.com".to_string(),
@@ -482,7 +482,7 @@ pub(crate) mod tests {
   /// Creates a new HTTP response with optional parameters.
   macro_rules! create_response {
     // Match with optional parameters
-    ($($key:ident: $value:expr),* $(,)?) => {{
+    ($($key:ident: $value:expr_2021),* $(,)?) => {{
         let mut response = ManifestResponse {
             status: "200".to_string(),
             version: "HTTP/1.1".to_string(),

--- a/proofs/src/program/manifest.rs
+++ b/proofs/src/program/manifest.rs
@@ -994,9 +994,9 @@ mod tests {
 
   macro_rules! create_manifest {
     (
-        $request:expr,
-        $response:expr
-        $(, $field:ident = $value:expr)* $(,)?
+        $request:expr_2021,
+        $response:expr_2021
+        $(, $field:ident = $value:expr_2021)* $(,)?
     ) => {{
         Manifest {
             // manifest_version: "1".to_string(),

--- a/proofs/src/program/mod.rs
+++ b/proofs/src/program/mod.rs
@@ -190,7 +190,7 @@ pub async fn run(
   #[cfg(feature = "timing")]
   let time = std::time::Instant::now();
   for (idx, &op_code) in
-    resized_rom.iter().enumerate().take_while(|(_, &op_code)| op_code != u64::MAX)
+    resized_rom.iter().enumerate().take_while(|&(_, &op_code)| op_code != u64::MAX)
   {
     info!("Step {} of ROM", idx);
     debug!("Opcode = {:?}", op_code);


### PR DESCRIPTION
- Upgrade to 2024 edition

TODO:
- WASM fails to build on a [unsafe extern](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/unsafe-extern.html) bug