### PR TITLE
chore: add pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## Issues fixed/closed
+
+- Closes #...
+- Fixes #...
+
+## What this does
+
+> Briefly describe the key changes introduced.
+> - What problem does this solve?
+> - Any breaking changes? (Yes/No, explain)
+> - Anything we should communicate to users?
+> - Link other related PRs/issues.
+
+## Why it's needed
+
+> Explain the motivation behind this PR.
+> - What problem does it solve?
+> - What impact does it have? (performance, security, UX, etc.)
+
+## How to test
+
+> Provide steps for testing if needed
+
+## Notes for reviewers
+
+> - What should reviewers focus on?
+> - Are there areas needing extra scrutiny?
+> - Any known limitations or future work?
+
+## Required Reviews
+
+Minimum number of reviews before merge: **1/2/3**   
+(Mention specific team members if applicable)
+


### PR DESCRIPTION
## What this does

- Adds a PR template

## Why it's needed

- Serves as a checklist to simplify PR submission and to add consistency

## Notes for reviewers

- We may want to replicate it to other repositories

## Required Reviews

Minimum number of reviews before merge: 1  

Merge at will
