### PR TITLE
chore: Auto Release 0.7.0

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -1,0 +1,54 @@
+name: Auto Version Bump
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'crates/**'
+
+jobs:
+  detect-and-bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          
+      - name: Install cargo-edit
+        run: cargo install cargo-edit
+          
+      - name: Detect changes and bump versions
+        id: detect-changes
+        run: |
+          # Get list of changed files
+          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD | grep "crates/" || echo "")
+          
+          # Extract unique crate names from changed files
+          CHANGED_CRATES=$(echo "$CHANGED_FILES" | grep -o "crates/[^/]*" | sort -u | cut -d'/' -f2)
+          
+          # For each changed crate, bump its minor version
+          for CRATE in $CHANGED_CRATES; do
+            if [ -f "crates/$CRATE/Cargo.toml" ]; then
+              echo "Bumping version for $CRATE"
+              (cd "crates/$CRATE" && cargo set-version --bump minor)
+            fi
+          done
+          
+          echo "changed_crates=$(echo $CHANGED_CRATES | tr '\n' ' ')" >> $GITHUB_ENV
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "chore: bump versions for affected crates"
+          title: "chore: automatic version bump"
+          branch: "auto-version-bump"
+          body: |
+            Automatic version bump for changed crates:
+            ${{ env.changed_crates }}

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -11,24 +11,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  verify-permissions:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check Token Permissions
-        run: |
-          # Test repository write access
-          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-               -H "Accept: application/vnd.github.v3+json" \
-               "https://api.github.com/repos/${{ github.repository }}" | \
-          jq -e '.permissions.push == true and .permissions.pull_requests == true' || {
-            echo "Error: Token does not have required permissions (push and pull_request)"
-            echo "Please ensure the workflow has 'contents: write' and 'pull-requests: write' permissions"
-            exit 1
-          }
-          echo "✓ Token permissions verified successfully"
-
   version-bump:
-    needs: verify-permissions
     if: ${{ !contains(github.event.head_commit.message, 'bump version') }}
     runs-on: ubuntu-latest
     steps:
@@ -37,11 +20,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
           
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: ./.github/actions/setup-rust-ubuntu
         with:
-          profile: minimal
-          toolchain: stable
+          rust-cache-key: version-bump
           
       - name: Cache cargo-edit
         uses: actions/cache@v3

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -2,18 +2,40 @@ name: Auto Version Bump
 
 on:
   push:
-    branches:
-      - main
+    branches: ["main"]
     paths:
       - 'crates/**'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  detect-and-bump:
+  verify-permissions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Token Permissions
+        run: |
+          # Test repository write access
+          curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               "https://api.github.com/repos/${{ github.repository }}" | \
+          jq -e '.permissions.push == true and .permissions.pull_requests == true' || {
+            echo "Error: Token does not have required permissions (push and pull_request)"
+            echo "Please ensure the workflow has 'contents: write' and 'pull-requests: write' permissions"
+            exit 1
+          }
+          echo "✓ Token permissions verified successfully"
+
+  version-bump:
+    needs: verify-permissions
+    if: ${{ !contains(github.event.head_commit.message, 'bump version') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -21,34 +43,81 @@ jobs:
           profile: minimal
           toolchain: stable
           
+      - name: Cache cargo-edit
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/bin/cargo-set-version
+          key: ${{ runner.os }}-cargo-edit
+          
       - name: Install cargo-edit
-        run: cargo install cargo-edit
+        run: |
+          if ! command -v cargo-set-version &> /dev/null; then
+            cargo install cargo-edit --version 0.13.1
+          fi
           
       - name: Detect changes and bump versions
         id: detect-changes
         run: |
-          # Get list of changed files
-          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD | grep "crates/" || echo "")
+          # Ensure we can find the last non-bump commit
+          LAST_NON_BUMP_COMMIT=$(git log --pretty=format:"%H" -i --grep="bump version" --invert-grep -n 1) || {
+            echo "Error: Could not find last non-bump commit"
+            exit 1
+          }
           
-          # Extract unique crate names from changed files
-          CHANGED_CRATES=$(echo "$CHANGED_FILES" | grep -o "crates/[^/]*" | sort -u | cut -d'/' -f2)
+          # Get list of changed files since last commit that's not a version bump
+          CHANGED_FILES=$(git diff --name-only $LAST_NON_BUMP_COMMIT HEAD | grep "crates/" || echo "")
+          
+          # Extract unique crate paths from changed files
+          CHANGED_CRATE_PATHS=$(echo "$CHANGED_FILES" | grep -o "crates/[^/]*" | sort -u || echo "")
+          
+          # Check if we found any changed crates
+          if [ -z "$CHANGED_CRATE_PATHS" ]; then
+            echo "No crate changes detected. Skipping version bump."
+            echo "changed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "Changes detected in the following crates:"
+          echo "$CHANGED_CRATE_PATHS"
+          
+          # Create list of changed crates for PR description
+          CRATE_NAMES=""
           
           # For each changed crate, bump its minor version
-          for CRATE in $CHANGED_CRATES; do
-            if [ -f "crates/$CRATE/Cargo.toml" ]; then
-              echo "Bumping version for $CRATE"
-              (cd "crates/$CRATE" && cargo set-version --bump minor)
+          for CRATE_PATH in $CHANGED_CRATE_PATHS; do
+            CRATE_NAME=$(echo "$CRATE_PATH" | cut -d'/' -f2)
+            if [ -f "$CRATE_PATH/Cargo.toml" ]; then
+              echo "Bumping version for $CRATE_NAME"
+              # Get current version before bump
+              CURRENT_VERSION=$(grep -m 1 "version = " "$CRATE_PATH/Cargo.toml" | cut -d'"' -f2)
+              
+              # Bump the version
+              (cd "$CRATE_PATH" && cargo set-version --bump minor)
+              
+              # Get new version after bump
+              NEW_VERSION=$(grep -m 1 "version = " "$CRATE_PATH/Cargo.toml" | cut -d'"' -f2)
+              
+              CRATE_NAMES="$CRATE_NAMES\n- $CRATE_NAME: $CURRENT_VERSION → $NEW_VERSION"
             fi
           done
           
-          echo "changed_crates=$(echo $CHANGED_CRATES | tr '\n' ' ')" >> $GITHUB_ENV
+          echo "crate_changes<<EOF" >> $GITHUB_OUTPUT
+          echo -e "$CRATE_NAMES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "changed=true" >> $GITHUB_OUTPUT
       
       - name: Create Pull Request
+        if: steps.detect-changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: "chore: bump versions for affected crates"
+          commit-message: "chore: bump version for modified crates"
           title: "chore: automatic version bump"
           branch: "auto-version-bump"
+          delete-branch: true
           body: |
-            Automatic version bump for changed crates:
-            ${{ env.changed_crates }}
+            ## Automatic Version Bump
+            
+            This PR updates the versions of the following crates:
+            ${{ steps.detect-changes.outputs.crate_changes }}
+            
+            Changes were detected in these crates after the last non-version-bump commit to main.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1426,7 +1426,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-tungstenite 0.25.1",
  "base64 0.22.1",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "client_ios"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "cargo_metadata",
  "client",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "client_wasm"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "cargo_metadata",
  "client",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "proofs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bellpepper-core",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "notary"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -7333,7 +7333,7 @@ dependencies = [
 
 [[package]]
 name = "web-prover-core"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "derive_more 2.0.1",
  "regex",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="client"
-version="0.6.0"
+version="0.7.0"
 edition="2021"
 build  ="build.rs"
 publish=false

--- a/client_ios/Cargo.toml
+++ b/client_ios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="client_ios"
-version="0.6.0"
+version="0.7.0"
 edition="2021"
 build  ="build.rs"
 publish=false

--- a/client_wasm/Cargo.toml
+++ b/client_wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="client_wasm"
-version="0.6.0"
+version="0.7.0"
 edition="2021"
 build  ="build.rs"
 publish=false

--- a/notary/Cargo.toml
+++ b/notary/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="notary"
-version="0.6.0"
+version="0.7.0"
 edition="2021"
 build  ="build.rs"
 

--- a/proofs/Cargo.toml
+++ b/proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="proofs"
-version="0.6.0"
+version="0.7.0"
 edition="2021"
 publish=false
 build  ="build.rs"

--- a/web-prover-core/Cargo.toml
+++ b/web-prover-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name   ="web-prover-core"
-version="0.1.0"
+version="0.7.0"
 edition="2021"
 
 [dependencies]


### PR DESCRIPTION
## What this does

This PR bumps the versions of changes crates to v0.7.0 and adds a continuous integration workflow that is triggered when a PR lands into main that doesn't have a commit message = "bump version". The workflow then finds which crates where changes and bumps the minor versions in a new PR. This automates creating version bumping pull requests and Closes #521 

## Why it's needed

This will streamline our versioning so that it is easy for downstream tools to have the latest versions as soon as changes are in. 

## How to test

You can test locally with act and a test file `test-event.json`
```json
{
  "push": {
    "ref": "refs/heads/main",
    "head_commit": {
      "message": "test: some changes in crates",
      "id": "1234567890abcdef"
    }
  }
}
```
To test run 

```
act push -W .github/workflows/bump_version.yaml --container-architecture linux/amd64 -e test-event.json
```

## Notes for reviewers

One current limitation here is that it will always bump the minor version. In the future it would be nice to explore using this tool [cargo-workspaces](https://crates.io/crates/cargo-workspaces). I have tried it out locally but it also builds the releases which we have some custom logic for in our release workflows. So i think that this is best in the short run.

## Required Reviews

Minimum number of reviews before merge: **1**   

