### PR TITLE
chore(ci): Allow running GHA workflows on a PR to any branch

### DIFF
--- a/.github/workflows/web-prover.yaml
+++ b/.github/workflows/web-prover.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: ["*"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Allows running CI actions on a PR to any branch
- Useful if you make a PR to a non-default branch, for example: #535 

## Required Reviews

Minimum number of reviews before merge: **1**

