### PR TITLE
feat!: Validate template variables in Manifest 

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -211,7 +211,7 @@ pub async fn verify<T: Serialize>(
     "https://{}:{}/v1/{}/verify",
     config.notary_host.clone(),
     config.notary_port.clone(),
-    config.mode.to_string(),
+    config.mode,
   );
 
   // TODO reqwest uses browsers fetch API for WASM target? if true, can't add trust anchors

--- a/client/src/tlsn_native.rs
+++ b/client/src/tlsn_native.rs
@@ -54,7 +54,7 @@ pub async fn setup_tcp_connection(
       "https://{}:{}/v1/{}?session_id={}",
       config.notary_host.clone(),
       config.notary_port.clone(),
-      config.mode.to_string(),
+      config.mode,
       session_id.clone(),
     ))
     .method("GET")

--- a/fixture/client.origo_tcp_local.json
+++ b/fixture/client.origo_tcp_local.json
@@ -28,11 +28,15 @@
 				},
 				"vars": {
 					"userId": {
-						"regex": "[a-z]{,20}+"
+						"description": "User ID for authentication",
+						"required": true,
+						"pattern": "[a-z]{,20}+"
 					},
 					"token": {
-						"type": "base64",
-						"length": 32
+						"description": "Authentication token",
+						"required": false,
+						"default": "abcdef1234567890abcdef1234567890",
+						"pattern": "^[A-Za-z0-9]{32}$"
 					}
 				}
 			},

--- a/fixture/client.proxy_tcp_local.json
+++ b/fixture/client.proxy_tcp_local.json
@@ -27,11 +27,15 @@
 				},
 				"vars": {
 					"userId": {
-						"regex": "[a-z]{,20}+"
+						"description": "User ID for authentication",
+						"required": true,
+						"pattern": "[a-z]{,20}+"
 					},
 					"token": {
-						"type": "base64",
-						"length": 32
+						"description": "Authentication token",
+						"required": false,
+						"default": "abcdef1234567890abcdef1234567890",
+						"pattern": "^[A-Za-z0-9]{32}$"
 					}
 				}
 			},

--- a/fixture/client.tee_tcp_local.json
+++ b/fixture/client.tee_tcp_local.json
@@ -31,11 +31,15 @@
 				},
 				"vars": {
 					"userId": {
-						"regex": "[a-z]{,20}+"
+						"description": "User ID for authentication",
+						"required": true,
+						"pattern": "[a-z]{,20}+"
 					},
 					"token": {
-						"type": "base64",
-						"length": 32
+						"description": "Authentication token",
+						"required": false,
+						"default": "abcdef1234567890abcdef1234567890",
+						"pattern": "^[A-Za-z0-9]{32}$"
 					}
 				}
 			},

--- a/fixture/examples/client.origo_reddit_local.json
+++ b/fixture/examples/client.origo_reddit_local.json
@@ -32,8 +32,16 @@
           "authorization": "Bearer <% authToken %>"
         },
         "vars": {
-          "userId": {},
-          "authToken": {}
+          "userId": {
+            "description": "Reddit username",
+            "required": true,
+            "pattern": "^[A-Za-z0-9_-]{3,20}$"
+          },
+          "authToken": {
+            "description": "Reddit authentication token",
+            "required": true,
+            "pattern": "^[A-Za-z0-9_-]+$"
+          }
         },
         "extra": {
           "headers": {

--- a/fixture/examples/client.origo_spotify_local.json
+++ b/fixture/examples/client.origo_spotify_local.json
@@ -25,7 +25,11 @@
           "authorization": "Bearer <% accessToken %>"
         },
         "vars": {
-          "accessToken": {}
+          "accessToken": {
+            "description": "Spotify access token",
+            "required": true,
+            "pattern": "^[A-Za-z0-9_-]+$"
+          }
         }
       },
       "response": {

--- a/web-prover-core/src/errors.rs
+++ b/web-prover-core/src/errors.rs
@@ -12,4 +12,32 @@ pub enum ManifestError {
   /// Serde operation failed
   #[error("Serde error occurred: {0}")]
   SerdeError(#[from] serde_json::Error),
+
+  /// Template-specific errors
+  #[error("Template error: {0}")]
+  Template(#[from] TemplateError),
+}
+
+/// Represents specific error conditions related to template handling
+#[derive(Debug, Error)]
+pub enum TemplateError {
+  /// Required template variable is not used in the template
+  #[error("Required variable `{0}` is not used in the template")]
+  UnusedRequiredVariable(String),
+
+  /// Non-required variable is missing a default value
+  #[error("Non-required variable `{0}` must have a default value")]
+  MissingDefaultValue(String),
+
+  /// Invalid regex pattern
+  #[error("Invalid regex pattern for `{0}`")]
+  InvalidRegexPattern(String),
+
+  /// Default value doesn't match the specified pattern
+  #[error("Default value for `{0}` does not match the specified pattern")]
+  DefaultValuePatternMismatch(String),
+
+  /// Empty regex pattern
+  #[error("Empty regex pattern for `{0}`")]
+  EmptyRegexPattern(String),
 }

--- a/web-prover-core/src/http.rs
+++ b/web-prover-core/src/http.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 use tracing::debug;
 pub use web_proof_circuits_witness_generator::json::JsonKey;
 
-use crate::errors::ManifestError;
+use crate::{errors::ManifestError, template, template::TemplateVar};
 
 /// Max HTTP headers
 pub const MAX_HTTP_HEADERS: usize = 25;
@@ -302,12 +302,9 @@ impl NotaryResponse {
 }
 
 /// Default HTTP version
-pub fn default_version() -> String { HTTP_1_1.to_string() }
+fn default_version() -> String { HTTP_1_1.to_string() }
 /// Default HTTP message
-pub fn default_message() -> String { "OK".to_string() }
-
-/// Returns an empty `HashMap` as the default value for `vars`
-fn default_empty_vars() -> HashMap<String, TemplateVar> { HashMap::new() }
+fn default_message() -> String { "OK".to_string() }
 
 /// HTTP Response items required for circuits
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -339,21 +336,19 @@ impl ManifestResponse {
   ///
   /// The validated HTTP response.
   pub fn validate(&self) -> Result<(), ManifestError> {
-    // TODO: What are legal statuses?
+    // We only support 200 and 201
     const VALID_STATUSES: [&str; 2] = ["200", "201"];
     if !VALID_STATUSES.contains(&self.status.as_str()) {
       return Err(ManifestError::InvalidManifest("Unsupported HTTP status".to_string()));
     }
-
-    // TODO: What HTTP versions are supported?
+    // We only support HTTP/1.1
     if self.version != "HTTP/1.1" {
       return Err(ManifestError::InvalidManifest(
         "Invalid HTTP version: ".to_string() + &self.version,
       ));
     }
 
-    // TODO: What is the max supported message length?
-    // TODO: Not covered by serde's #default annotation. Is '""' a valid message?
+    // An empty message is not allowed
     if self.message.len() > 1024 || self.message.is_empty() {
       return Err(ManifestError::InvalidManifest(
         "Invalid message length: ".to_string() + &self.message,
@@ -400,22 +395,8 @@ impl ManifestResponse {
   }
 }
 
-/// Template variable type
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct TemplateVar {
-  /// Optional description for the end user
-  pub description: Option<String>,
-  /// Indicates if the value is required
-  #[serde(default = "default_required")]
-  pub required:    bool,
-  /// A default value, must be set when `required` is false
-  pub default:     Option<String>,
-  /// Regex pattern for validation of user input
-  pub pattern:     Option<String>,
-}
-
-/// Default value for the required field is true
-fn default_required() -> bool { true }
+/// Returns an empty `HashMap` as the default value for `vars`
+fn default_empty_vars() -> HashMap<String, TemplateVar> { HashMap::new() }
 
 /// HTTP Request items required for circuits
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -472,78 +453,42 @@ impl ManifestRequest {
     Ok(())
   }
 
-  pub fn validate_vars(&self) -> Result<(), ManifestError> {
-    let mut all_tokens = vec![];
+  fn collect_tokens(&self) -> Vec<String> {
+    let mut all_tokens = Vec::new();
 
-    // Parse and validate tokens in the body
-    if let Some(body_tokens) = self.body.as_ref().map(extract_tokens) {
-      for token in &body_tokens {
-        if !self.vars.contains_key(token) {
-          return Err(ManifestError::InvalidManifest(format!(
-            "Token `<% {} %>` not declared in `vars`",
-            token
-          )));
-        }
-      }
+    // Collect tokens from body
+    if let Some(body_tokens) = self.body.as_ref().map(template::extract_tokens) {
       all_tokens.extend(body_tokens);
     }
 
-    // Parse and validate tokens in headers
+    // Collect tokens from headers
     for value in self.headers.values() {
-      let header_tokens = extract_tokens(&serde_json::Value::String(value.clone()));
-      for token in &header_tokens {
-        if !self.vars.contains_key(token) {
-          return Err(ManifestError::InvalidManifest(format!(
-            "Token `<% {} %>` not declared in `vars`",
-            token
-          )));
-        }
-      }
+      let header_tokens = template::extract_tokens(&serde_json::Value::String(value.clone()));
       all_tokens.extend(header_tokens);
     }
 
-    // Validate each `vars` entry
-    for (key, var_def) in &self.vars {
-      // Check if the variable is used in the template
+    all_tokens
+  }
+
+  fn validate_tokens(&self, tokens: &[String]) -> Result<(), ManifestError> {
+    for token in tokens {
+      if !self.vars.contains_key(token) {
+        return Err(ManifestError::InvalidManifest(format!(
+          "Token `<% {} %>` not declared in `vars`",
+          token
+        )));
+      }
+    }
+    Ok(())
+  }
+
+  pub fn validate_vars(&self) -> Result<(), ManifestError> {
+    let all_tokens = self.collect_tokens();
+    self.validate_tokens(&all_tokens)?;
+
+    for (key, variable) in &self.vars {
       let is_used = all_tokens.contains(key);
-
-      // If the variable is required but not used, return an error
-      if var_def.required && !is_used {
-        return Err(ManifestError::InvalidManifest(format!(
-          "Required variable `{}` is not used in the template",
-          key
-        )));
-      }
-
-      // If the variable is not required, it must have a default value
-      if !var_def.required && var_def.default.is_none() {
-        return Err(ManifestError::InvalidManifest(format!(
-          "Non-required variable `{}` must have a default value",
-          key
-        )));
-      }
-
-      // Validate pattern (if defined)
-      if let Some(pattern) = var_def.pattern.as_ref() {
-        // Using `regress` crate for compatibility with ECMAScript regular expressions
-        let _regex = regress::Regex::new(pattern).map_err(|_| {
-          ManifestError::InvalidManifest(format!("Invalid regex pattern for `{}`", key))
-        })?;
-
-        // If there's a default value, validate it against the pattern
-        if let Some(default_value) = var_def.default.as_ref() {
-          let regex = regex::Regex::new(pattern).map_err(|_| {
-            ManifestError::InvalidManifest(format!("Invalid regex pattern for `{}`", key))
-          })?;
-
-          if !regex.is_match(default_value) {
-            return Err(ManifestError::InvalidManifest(format!(
-              "Default value for `{}` does not match the specified pattern",
-              key
-            )));
-          }
-        }
-      }
+      variable.validate(key, is_used)?;
     }
 
     Ok(())
@@ -644,37 +589,6 @@ impl ManifestRequest {
     // self.method == other.method && self.url == other.url && self.body == other.body
     self.method == other.method && self.url == other.url
   }
-}
-
-fn extract_tokens(value: &serde_json::Value) -> Vec<String> {
-  let mut tokens = vec![];
-
-  match value {
-    serde_json::Value::String(s) => {
-      let token_regex = regex::Regex::new(r"<%\s*(\w+)\s*%>").unwrap();
-      for capture in token_regex.captures_iter(s) {
-        if let Some(token) = capture.get(1) {
-          // Extract token name
-          tokens.push(token.as_str().to_string());
-        }
-      }
-    },
-    serde_json::Value::Object(map) => {
-      // Recursively parse nested objects
-      for (_, v) in map {
-        tokens.extend(extract_tokens(v));
-      }
-    },
-    serde_json::Value::Array(arr) => {
-      // Recursively parse arrays
-      for v in arr {
-        tokens.extend(extract_tokens(v));
-      }
-    },
-    _ => {},
-  }
-
-  tokens
 }
 
 #[cfg(test)]

--- a/web-prover-core/src/lib.rs
+++ b/web-prover-core/src/lib.rs
@@ -3,4 +3,5 @@ pub mod http;
 pub mod manifest;
 
 pub mod proof;
+mod template;
 pub mod test_utils;

--- a/web-prover-core/src/manifest.rs
+++ b/web-prover-core/src/manifest.rs
@@ -33,11 +33,9 @@ impl Manifest {
     self.request.validate()?;
     self.response.validate()?;
 
-    // TODO: Do we want to run this here instead of in Request::validate in order to cross-examine
-    //  Request and Response template vars?
-    // TODO: Commented out because it breaks when existing fixtures, i.e. tokens encoded in the
-    //  body of client.tee_tcp_local.json
-    // self.request.validate_vars()?;
+    // Validate template variables
+    self.request.validate_vars()?;
+
     Ok(())
   }
 
@@ -77,14 +75,13 @@ mod tests {
   use std::collections::HashMap;
 
   use crate::{
-    errors::ProofError,
-    program::{
-      http::{JsonKey, ManifestRequest, ManifestResponse, ManifestResponseBody, TemplateVar},
-      manifest::HTTP_1_1,
-      plain_manifest::Manifest,
+    errors::ManifestError,
+    http::{
+      JsonKey, ManifestRequest, ManifestResponse, ManifestResponseBody, TemplateVar, HTTP_1_1,
     },
+    manifest::Manifest,
     request, response,
-    tests::inputs::TEST_MANIFEST,
+    test_utils::TEST_MANIFEST,
   };
 
   macro_rules! create_manifest {
@@ -175,10 +172,17 @@ mod tests {
   fn test_parse_manifest_without_vars() {
     let manifest: Manifest = serde_json::from_str(TEST_MANIFEST_WITHOUT_VARS).unwrap();
     let result = manifest.validate();
-    assert!(result.is_ok());
+    assert!(result.is_err());
 
     assert!(manifest.request.body.is_none()); // Optional field we omitted
     assert_eq!(manifest.request.vars, HashMap::new()); // Optional field we provide default for
+
+    // Check that the error is about the missing token
+    if let Err(ManifestError::InvalidManifest(message)) = result {
+      assert!(message.contains("Token `<% token %>` not declared in `vars`"));
+    } else {
+      panic!("Expected ManifestError::InvalidManifest about missing token");
+    }
   }
 
   #[test]
@@ -217,14 +221,14 @@ mod tests {
     }
   }
 
-  #[ignore] // TODO: Unignore after fixtures are fixed and token validation is re-enabled
   #[test]
   fn test_manifest_validation_missing_vars() {
     let mut vars = HashMap::new();
     vars.insert("TOKEN".to_string(), TemplateVar {
-      regex:  Some("^[A-Za-z0-9]+$".to_string()),
-      length: Some(20),
-      r#type: Some("base64".to_string()),
+      description: Some("Authentication token".to_string()),
+      required:    true,
+      default:     None,
+      pattern:     Some("^[A-Za-z0-9]+$".to_string()),
     });
     let manifest = create_manifest!(
       request!(

--- a/web-prover-core/src/manifest.rs
+++ b/web-prover-core/src/manifest.rs
@@ -76,11 +76,10 @@ mod tests {
 
   use crate::{
     errors::ManifestError,
-    http::{
-      JsonKey, ManifestRequest, ManifestResponse, ManifestResponseBody, TemplateVar, HTTP_1_1,
-    },
+    http::{JsonKey, ManifestRequest, ManifestResponse, ManifestResponseBody, HTTP_1_1},
     manifest::Manifest,
     request, response,
+    template::TemplateVar,
     test_utils::TEST_MANIFEST,
   };
 

--- a/web-prover-core/src/template.rs
+++ b/web-prover-core/src/template.rs
@@ -130,6 +130,16 @@ mod tests {
     pub fn optional(description: &str, default: &str, pattern: Option<&str>) -> Self {
       Self::new(Some(description), false, Some(default), pattern)
     }
+
+    /// Creates a new optional template variable without a default value.
+    pub fn optional_without_default(description: &str, pattern: Option<&str>) -> Self {
+      Self::new(Some(description), false, None, pattern)
+    }
+
+    /// Creates a new required template variable with a default value.
+    pub fn required_with_default(description: &str, default: &str, pattern: Option<&str>) -> Self {
+      Self::new(Some(description), true, Some(default), pattern)
+    }
   }
 
   #[test]
@@ -147,12 +157,7 @@ mod tests {
 
   #[test]
   fn test_validate_vars_required_not_used() {
-    let var = TemplateVar {
-      description: Some("This is a required variable".to_string()),
-      required:    true,
-      default:     None,
-      pattern:     None,
-    };
+    let var = TemplateVar::required("This is a required variable", None);
 
     let result = var.validate("unused_var", false);
     assert!(result.is_err());
@@ -165,12 +170,7 @@ mod tests {
 
   #[test]
   fn test_validate_vars_non_required_without_default() {
-    let var = TemplateVar {
-      description: Some("This is an optional variable".to_string()),
-      required:    false,
-      default:     None,
-      pattern:     None,
-    };
+    let var = TemplateVar::optional_without_default("This is an optional variable", None);
 
     let result = var.validate("optional_var", true);
     assert!(result.is_err());
@@ -196,19 +196,9 @@ mod tests {
 
   #[test]
   fn test_validate_vars_valid() {
-    let var1 = TemplateVar {
-      description: Some("This is a header variable".to_string()),
-      required:    true,
-      default:     None,
-      pattern:     Some("^[A-Za-z0-9]+$".to_string()),
-    };
-
-    let var2 = TemplateVar {
-      description: Some("This is a body variable".to_string()),
-      required:    false,
-      default:     Some("default123".to_string()),
-      pattern:     Some("^[A-Za-z0-9]+$".to_string()),
-    };
+    let var1 = TemplateVar::required("This is a header variable", Some("^[A-Za-z0-9]+$"));
+    let var2 =
+      TemplateVar::optional("This is a body variable", "default123", Some("^[A-Za-z0-9]+$"));
 
     assert!(var1.validate("header_var", true).is_ok());
     assert!(var2.validate("body_var", true).is_ok());

--- a/web-prover-core/src/template.rs
+++ b/web-prover-core/src/template.rs
@@ -1,0 +1,96 @@
+use serde::{Deserialize, Serialize};
+
+use crate::errors::ManifestError;
+
+/// Default value for the required field is true
+fn default_required() -> bool { true }
+
+/// Template variable type
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TemplateVar {
+  /// Optional description for the end user
+  pub description: Option<String>,
+  /// Indicates if the value is required
+  #[serde(default = "default_required")]
+  pub required:    bool,
+  /// A default value, must be set when `required` is false
+  pub default:     Option<String>,
+  /// Regex pattern for validation of user input
+  pub pattern:     Option<String>,
+}
+
+impl TemplateVar {
+  pub fn validate(&self, key: &str, is_used: bool) -> Result<(), ManifestError> {
+    // Check required variable usage
+    if self.required && !is_used {
+      return Err(ManifestError::InvalidManifest(format!(
+        "Required variable `{}` is not used in the template",
+        key
+      )));
+    }
+
+    // Check non-required variable default value
+    if !self.required && self.default.is_none() {
+      return Err(ManifestError::InvalidManifest(format!(
+        "Non-required variable `{}` must have a default value",
+        key
+      )));
+    }
+
+    // Validate pattern if present
+    if let Some(pattern) = self.pattern.as_ref() {
+      // Using `regress` crate for compatibility with ECMAScript regular expressions
+      let _regex = regress::Regex::new(pattern).map_err(|_| {
+        ManifestError::InvalidManifest(format!("Invalid regex pattern for `{}`", key))
+      })?;
+
+      // Validate default value against pattern if present
+      if let Some(default_value) = self.default.as_ref() {
+        let regex = regex::Regex::new(pattern).map_err(|_| {
+          ManifestError::InvalidManifest(format!("Invalid regex pattern for `{}`", key))
+        })?;
+
+        if !regex.is_match(default_value) {
+          return Err(ManifestError::InvalidManifest(format!(
+            "Default value for `{}` does not match the specified pattern",
+            key
+          )));
+        }
+      }
+    }
+
+    Ok(())
+  }
+}
+
+/// Extract tokens from a JSON value
+pub fn extract_tokens(value: &serde_json::Value) -> Vec<String> {
+  let mut tokens = vec![];
+
+  match value {
+    serde_json::Value::String(s) => {
+      let token_regex = regex::Regex::new(r"<%\s*(\w+)\s*%>").unwrap();
+      for capture in token_regex.captures_iter(s) {
+        if let Some(token) = capture.get(1) {
+          // Extract token name
+          tokens.push(token.as_str().to_string());
+        }
+      }
+    },
+    serde_json::Value::Object(map) => {
+      // Recursively parse nested objects
+      for (_, v) in map {
+        tokens.extend(extract_tokens(v));
+      }
+    },
+    serde_json::Value::Array(arr) => {
+      // Recursively parse arrays
+      for v in arr {
+        tokens.extend(extract_tokens(v));
+      }
+    },
+    _ => {},
+  }
+
+  tokens
+}

--- a/web-prover-core/src/template.rs
+++ b/web-prover-core/src/template.rs
@@ -1,25 +1,41 @@
+//! Template handling for manifest variables.
+//!
+//! This module provides functionality for handling template variables in manifests.
+//! Template variables are used to parameterize manifest fields and are identified
+//! by the pattern `<% variable_name %>`.
+
+use regex;
+use regress;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::ManifestError;
 
-/// Default value for the required field is true
-fn default_required() -> bool { true }
+/// Regular expression for matching template variables in text.
+///
+/// Matches patterns like `<% variable_name %>` where variable_name
+/// consists of word characters.
+const TEMPLATE_VAR_PATTERN: &str = r"<%\s*(\w+)\s*%>";
 
-/// Template variable type
+/// Default value for the required field is true
+const DEFAULT_REQUIRED: bool = true;
+fn default_required() -> bool { DEFAULT_REQUIRED }
+
+/// Template variables are identified in `Manifest` fields using the syntax `<% variable_name %>`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TemplateVar {
-  /// Optional description for the end user
+  /// Optional description explaining the purpose of this variable
   pub description: Option<String>,
-  /// Indicates if the value is required
+  /// Whether this variable must be provided (defaults to true)
   #[serde(default = "default_required")]
   pub required:    bool,
-  /// A default value, must be set when `required` is false
+  /// Default value for optional variables
   pub default:     Option<String>,
-  /// Regex pattern for validation of user input
+  /// Regular expression pattern for validating values
   pub pattern:     Option<String>,
 }
 
 impl TemplateVar {
+  /// Validates the template variable
   pub fn validate(&self, key: &str, is_used: bool) -> Result<(), ManifestError> {
     // Check required variable usage
     if self.required && !is_used {
@@ -36,9 +52,13 @@ impl TemplateVar {
         key
       )));
     }
-
     // Validate pattern if present
     if let Some(pattern) = self.pattern.as_ref() {
+      // Check for empty pattern
+      if pattern.is_empty() {
+        return Err(ManifestError::InvalidManifest(format!("Invalid regex pattern for `{}`", key)));
+      }
+
       // Using `regress` crate for compatibility with ECMAScript regular expressions
       let _regex = regress::Regex::new(pattern).map_err(|_| {
         ManifestError::InvalidManifest(format!("Invalid regex pattern for `{}`", key))
@@ -58,39 +78,236 @@ impl TemplateVar {
         }
       }
     }
-
     Ok(())
   }
 }
 
-/// Extract tokens from a JSON value
+/// Extracts template variable tokens from a JSON value.
 pub fn extract_tokens(value: &serde_json::Value) -> Vec<String> {
-  let mut tokens = vec![];
+  let mut tokens = Vec::new();
+  let token_regex = regex::Regex::new(TEMPLATE_VAR_PATTERN).unwrap();
 
   match value {
-    serde_json::Value::String(s) => {
-      let token_regex = regex::Regex::new(r"<%\s*(\w+)\s*%>").unwrap();
+    serde_json::Value::String(s) =>
       for capture in token_regex.captures_iter(s) {
         if let Some(token) = capture.get(1) {
           // Extract token name
           tokens.push(token.as_str().to_string());
         }
-      }
-    },
-    serde_json::Value::Object(map) => {
-      // Recursively parse nested objects
-      for (_, v) in map {
+      },
+    serde_json::Value::Object(map) =>
+    // Recursively extract tokens from nested objects
+      for v in map.values() {
         tokens.extend(extract_tokens(v));
-      }
-    },
-    serde_json::Value::Array(arr) => {
-      // Recursively parse arrays
+      },
+    serde_json::Value::Array(arr) =>
+    // Recursively extract tokens from nested arrays
       for v in arr {
         tokens.extend(extract_tokens(v));
-      }
-    },
+      },
     _ => {},
   }
 
   tokens
+}
+
+#[cfg(test)]
+mod tests {
+  use serde_json::json;
+
+  use super::*;
+
+  impl TemplateVar {
+    /// Creates a new template variable with the specified parameters.
+    pub fn new(
+      description: Option<&str>,
+      required: bool,
+      default: Option<&str>,
+      pattern: Option<&str>,
+    ) -> Self {
+      TemplateVar {
+        description: description.map(String::from),
+        required,
+        default: default.map(String::from),
+        pattern: pattern.map(String::from),
+      }
+    }
+
+    /// Creates a new required template variable.
+    pub fn required(description: &str, pattern: Option<&str>) -> Self {
+      Self::new(Some(description), true, None, pattern)
+    }
+
+    /// Creates a new optional template variable with a default value.
+    pub fn optional(description: &str, default: &str, pattern: Option<&str>) -> Self {
+      Self::new(Some(description), false, Some(default), pattern)
+    }
+  }
+
+  #[test]
+  fn test_validate_vars_with_missing_token() {
+    let var = TemplateVar::required("Test var", None);
+
+    let result = var.validate("missing_token", false);
+    assert!(result.is_err());
+    assert!(
+      matches!(result, Err(ManifestError::InvalidManifest(msg)) if msg.contains("Required variable `missing_token` is not used in the template"))
+    );
+  }
+
+  #[test]
+  fn test_validate_vars_required_not_used() {
+    let var = TemplateVar {
+      description: Some("This is a required variable".to_string()),
+      required:    true,
+      default:     None,
+      pattern:     None,
+    };
+
+    let result = var.validate("unused_var", false);
+    assert!(result.is_err());
+    assert!(
+      matches!(result, Err(ManifestError::InvalidManifest(msg)) if msg.contains("Required variable `unused_var` is not used in the template"))
+    );
+  }
+
+  #[test]
+  fn test_validate_vars_non_required_without_default() {
+    let var = TemplateVar {
+      description: Some("This is an optional variable".to_string()),
+      required:    false,
+      default:     None,
+      pattern:     None,
+    };
+
+    let result = var.validate("optional_var", true);
+    assert!(result.is_err());
+    assert!(
+      matches!(result, Err(ManifestError::InvalidManifest(msg)) if msg.contains("Non-required variable `optional_var` must have a default value"))
+    );
+  }
+
+  #[test]
+  fn test_validate_vars_default_not_matching_pattern() {
+    let var = TemplateVar::optional("Variable with pattern", "abc123", Some("^[0-9]+$"));
+
+    let result = var.validate("pattern_var", true);
+    assert!(result.is_err());
+    assert!(
+      matches!(result, Err(ManifestError::InvalidManifest(msg)) if msg.contains("Default value for `pattern_var` does not match the specified pattern"))
+    );
+  }
+
+  #[test]
+  fn test_validate_vars_valid() {
+    let var1 = TemplateVar {
+      description: Some("This is a header variable".to_string()),
+      required:    true,
+      default:     None,
+      pattern:     Some("^[A-Za-z0-9]+$".to_string()),
+    };
+
+    let var2 = TemplateVar {
+      description: Some("This is a body variable".to_string()),
+      required:    false,
+      default:     Some("default123".to_string()),
+      pattern:     Some("^[A-Za-z0-9]+$".to_string()),
+    };
+
+    assert!(var1.validate("header_var", true).is_ok());
+    assert!(var2.validate("body_var", true).is_ok());
+  }
+
+  #[test]
+  fn test_extract_tokens() {
+    let json = serde_json::json!({
+        "string": "Hello <% token1 %> World <% token2 %>",
+        "nested": {
+            "array": ["<% token3 %>", "plain text"],
+            "object": {"key": "<% token4 %>"}
+        }
+    });
+
+    let tokens = extract_tokens(&json);
+    assert_eq!(tokens.len(), 4);
+    assert!(tokens.contains(&"token1".to_string()));
+    assert!(tokens.contains(&"token2".to_string()));
+    assert!(tokens.contains(&"token3".to_string()));
+    assert!(tokens.contains(&"token4".to_string()));
+  }
+
+  #[test]
+  fn test_validate_vars_invalid_regex_pattern() {
+    let var = TemplateVar {
+      description: Some("Variable with invalid regex".to_string()),
+      required:    false,
+      default:     Some("test".to_string()),
+      pattern:     Some("[invalid regex(".to_string()),
+    };
+
+    let result = var.validate("invalid_pattern", true);
+    assert!(result.is_err());
+    assert!(
+      matches!(result, Err(ManifestError::InvalidManifest(msg)) if msg.contains("Invalid regex pattern"))
+    );
+  }
+
+  #[test]
+  fn test_extract_tokens_empty_values() {
+    let json = serde_json::json!({
+        "empty_string": "",
+        "null": null,
+        "number": 42,
+        "boolean": true
+    });
+
+    let tokens = extract_tokens(&json);
+    assert!(tokens.is_empty());
+  }
+
+  #[test]
+  fn test_validate_vars_empty_pattern() {
+    let var = TemplateVar {
+      description: None,
+      required:    false,
+      default:     Some("test".to_string()),
+      pattern:     Some("".to_string()),
+    };
+
+    let result = var.validate("empty_pattern", true);
+    assert!(result.is_err());
+    assert!(
+      matches!(result, Err(ManifestError::InvalidManifest(msg)) if msg.contains("Invalid regex pattern"))
+    );
+  }
+
+  #[test]
+  fn test_extract_tokens_nested_structure() {
+    let json = json!({
+        "object": {
+            "nested": {
+                "value": "Hello <% user %>"
+            },
+            "array": [
+                "First <% index %>",
+                {"deep": "<% token %>"}
+            ]
+        }
+    });
+
+    let tokens = extract_tokens(&json);
+    assert_eq!(tokens.len(), 3);
+    assert!(tokens.contains(&"user".to_string()));
+    assert!(tokens.contains(&"index".to_string()));
+    assert!(tokens.contains(&"token".to_string()));
+  }
+
+  #[test]
+  fn test_template_var_defaults() {
+    let var = TemplateVar::new(None, DEFAULT_REQUIRED, None, None);
+    assert!(var.required);
+    assert!(var.description.is_none());
+    assert!(var.default.is_none());
+    assert!(var.pattern.is_none());
+  }
 }

--- a/web-prover-core/src/test_utils.rs
+++ b/web-prover-core/src/test_utils.rs
@@ -17,11 +17,16 @@ pub const TEST_MANIFEST: &str = r#"
         },
         "vars": {
             "userId": {
-                "regex": "[a-z]{,20}+"
+                "description": "Reddit username for karma lookup",
+                "required": true,
+                "pattern": "^[a-z]{1,20}$",
+                "default": null
             },
             "token": {
-                "type": "base64",
-                "length": 32
+                "description": "Authentication token",
+                "required": false,
+                "pattern": "^[A-Za-z0-9+/]{32}={0,2}$",
+                "default": "abcdefghijklmnopqrstuvwxyz123456=="
             }
         }
     },


### PR DESCRIPTION
## Related Issues

- Closes #517 

## Summary

- Updates template variables to match the new Manifest specification. 
- Supports descriptions, required/optional flags, default values, and RegExp pattern validation
- Token extraction is only supported on Manifest `.body` and `.headers`

```json
{
  "vars": {
    "accessToken": {                     // Variable name, referenced as <% accessToken %>
      "description": "Spotify API token", // Human-readable description
      "required": true,                  // Must be provided by the user
      "pattern": "^[A-Za-z0-9_-]+$",    // Regex pattern for validation
      "default": null                    // No default (required=true)
    },
}
```

## Breaking Changes

- Backward-incompatible changes to template variable format in manifests

## Required Reviews

Minimum number of reviews before merge: **1**
