### PR TITLE
remove redundant variables in manifest

### DIFF
--- a/.github/workflows/web-prover.yaml
+++ b/.github/workflows/web-prover.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/client/src/origo.rs
+++ b/client/src/origo.rs
@@ -113,7 +113,7 @@ pub(crate) async fn proxy_and_sign_and_generate_proof(
     decrypt_tls_ciphertext(&witness)?;
 
   // generate NIVC proofs for request and response
-  let manifest = config.proving.manifest.unwrap();
+  let manifest = config.manifest;
 
   let mut proof = generate_proof(
     &manifest.clone().into(),

--- a/client/src/origo_native.rs
+++ b/client/src/origo_native.rs
@@ -278,7 +278,7 @@ async fn handle_tee_mode(
   let mut framed_reunited_socket =
     Framed::new(reunited_socket.compat(), LengthDelimitedCodec::new());
 
-  let manifest_bytes: Vec<u8> = config.proving.manifest.unwrap().try_into()?;
+  let manifest_bytes: Vec<u8> = config.manifest.try_into()?;
   framed_reunited_socket.send(Bytes::from(manifest_bytes)).await?;
 
   let origo_secret = OrigoSecrets::from_origo_conn(&origo_conn);

--- a/client/src/origo_wasm32.rs
+++ b/client/src/origo_wasm32.rs
@@ -201,7 +201,7 @@ async fn handle_tee_mode(
   let mut framed_reunited_socket =
     Framed::new(reunited_socket.compat(), LengthDelimitedCodec::new());
 
-  let manifest = config.proving.manifest.unwrap();
+  let manifest = config.manifest;
   let manifest_bytes: Vec<u8> = (&manifest).try_into().unwrap();
   framed_reunited_socket.send(Bytes::from(manifest_bytes)).await?;
 

--- a/fixture/client.origo_tcp_local.json
+++ b/fixture/client.origo_tcp_local.json
@@ -3,57 +3,50 @@
 	"notary_host": "localhost",
 	"notary_port": 7443,
 	"notary_ca_cert": "MIIFszCCA5ugAwIBAgIUeXLQmnjeXsHpGji7xA8oJjjw7WwwDQYJKoZIhvcNAQELBQAwaTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExEjAQBgNVBAcMCVBhbG8gQWx0bzEVMBMGA1UECgwMT3JnYW5pemF0aW9uMRowGAYDVQQDDBFMb2NhbGhvc3QgUm9vdCBDQTAeFw0yNDA2MDcyMjUyNDBaFw0yOTA2MDYyMjUyNDBaMGkxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRIwEAYDVQQHDAlQYWxvIEFsdG8xFTATBgNVBAoMDE9yZ2FuaXphdGlvbjEaMBgGA1UEAwwRTG9jYWxob3N0IFJvb3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDIHMEL9gVSxT/J0qS4xDkDZs1d1UG0+z6NFLLsGdV7gu0ZJbDPlNd0kpjWsisVNB7TcqWoq5ROK5CR+6lZxXC8nbqr2YAJ2O8mHIXcYv7msAN3UYxtM6v1M7K+vNMJdDjZVAxcOKq5R7uUDUPw1weePz6eVEjntAW8mUjqkfnCqYml943Ud3724SkI5wyUT9rKS3bk6hvneq1ah/b1zRGDF2gp+T/oNe4ieS/LGoIUluE2csGRXtt542gpJnw5L54JASmGgt6hunUSWtoaht7Qxv6hYpieu4iHqZY1kfcFDjDH2WI16g1YqrWHzk1l7vWNLVDEcK3kdSQ1GmYAij8ZjAi0LJizLwtN//EkfxiOPlV435itK3uugY+etxrk77BeA6PmVcpZeLLXYuKSrzfaBh0ifP2p0uRlShURi5Rz4IE0I7wHkZ44x9MKYv8YzXK7O29HD158tgorxqwwKmkHqSxWpp7SRKvNnMulHN/el+IKDrPeBhVXsSSkd6U+/H61q7i0SY9TqqhdiMQLW/efK9LkVRen5myhwqogwiF/42Jp2nrCeuzv5YDsAFSrQ0lukW+Hz7FXV+0axnKeXZ08Nd+IS1BhGyMgHo6PWMP1fWyfO0DJVUfIqrHqvBy8bW0yNOuhiyU2oeyDRKv75OMxpIrUeX3qvmrVcYUPvfXsVQIDAQABo1MwUTAdBgNVHQ4EFgQUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wHwYDVR0jBBgwFoAUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEARliSCLdjNI5fFkNwXDK6k6jN5hITrY07XIawUIEwinjQqgLkYFvzXbMtfLwsWmxMPjDVYYDa5Y2NAGcH08b//2z9EuHxMOTOFTKr59BEcVxV1cxV+lspAunH8DLSlLJhf/EeR+MhIIHAfhlE8V7lvlE1EbM+Uj5JYIeefV/4omsGrphyHD3oSJAQDae0su200I/i2yAaTrwXLZ4HtaXsnxKZ4PMPFWaLvMQ8DsLgx2VB3/vQJn74Xepau6mYEWlRnUu90mj79gJOnwBKPlLojF6dJOMIJ2YHr9fI8sUfkVwPFVlkDKJcr0ll5RL3O/naNlLQZuOgijOM5YF5iTrefliVodEHpBPID2mhtq/E+ZIQWLpik8ulsJ8ufN9YfrbjbsiC/KeoMqoFCImRSyMGQDMADo4EV3DNfDFvfrHx0qBMmJ0nkhuGobphegMPCjZ3axvQwQulKuHXmFpAvGYcpK/twBMC1MJkV04tIwVEDZG6id5oKYtrIXHdSFshf6r3z4bbgq6kJnOxZ8Vo4cEw/dgc3hRivr+HnxOJcEk2CTQlCVOiCQAg64OqDEOoswVg6nzoO3RJhFatu+abO22MIXPNGma02zBoQZLYpGzL9z6pMnPKjL15G9H1SYVSTGhmq+GVtdRibg8rLBciSm3ERd7gNRqvYP5GrjCtUIbOTEc=",
-	"target_method": "GET",
-	"target_url": "https://www.apple.com/shop/experience-meta",
-	"target_headers": {},
 	"target_body": "",
 	"max_sent_data": 10000,
 	"max_recv_data": 10000,
-	"proving": {
-		"manifest": {
-			"manifestVersion": "1",
-			"id": "reddit-user-karma",
-			"title": "Total Reddit Karma",
-			"description": "Generate a proof that you have a certain amount of karma",
-			"prepareUrl": "https://www.reddit.com/login/",
-			"request": {
-				"method": "GET",
-				"version": "HTTP/1.1",
-				"url": "https://www.apple.com/shop/experience-meta",
-				"headers": {
-					"accept-encoding": "identity"
-				},
-				"body": {
-					"userId": "<% userId %>"
-				},
-				"vars": {
-					"userId": {
-						"description": "User ID for authentication",
-						"required": true,
-						"pattern": "[a-z]{,20}+"
-					},
-					"token": {
-						"description": "Authentication token",
-						"required": false,
-						"default": "abcdef1234567890abcdef1234567890",
-						"pattern": "^[A-Za-z0-9]{32}$"
-					}
-				}
+	"manifest": {
+		"manifestVersion": "1",
+		"id": "reddit-user-karma",
+		"title": "Total Reddit Karma",
+		"description": "Generate a proof that you have a certain amount of karma",
+		"prepareUrl": "https://www.reddit.com/login/",
+		"request": {
+			"method": "GET",
+			"url": "https://www.apple.com/shop/experience-meta",
+			"headers": {
+				"accept-encoding": "identity"
 			},
-			"response": {
-				"status": "200",
-				"version": "HTTP/1.1",
-				"message": "OK",
-				"headers": {
-					"Content-Type": "application/json"
+			"body": {
+				"userId": "<% userId %>"
+			},
+			"vars": {
+				"userId": {
+					"description": "User ID for authentication",
+					"required": true,
+					"pattern": "[a-z]{,20}+"
 				},
-				"body": {
-					"json": [
-						"head",
-						"status"
-					],
-					"contains": "this_string_exists_in_body"
+				"token": {
+					"description": "Authentication token",
+					"required": false,
+					"default": "abcdef1234567890abcdef1234567890",
+					"pattern": "^[A-Za-z0-9]{32}$"
 				}
+			}
+		},
+		"response": {
+			"status": "200",
+			"message": "OK",
+			"headers": {
+				"Content-Type": "application/json"
+			},
+			"body": {
+				"json": [
+					"head",
+					"status"
+				],
+				"contains": "this_string_exists_in_body"
 			}
 		}
 	}

--- a/fixture/client.proxy_tcp_local.json
+++ b/fixture/client.proxy_tcp_local.json
@@ -3,55 +3,47 @@
 	"notary_host": "localhost",
 	"notary_port": 7443,
 	"notary_ca_cert": "MIIFszCCA5ugAwIBAgIUeXLQmnjeXsHpGji7xA8oJjjw7WwwDQYJKoZIhvcNAQELBQAwaTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExEjAQBgNVBAcMCVBhbG8gQWx0bzEVMBMGA1UECgwMT3JnYW5pemF0aW9uMRowGAYDVQQDDBFMb2NhbGhvc3QgUm9vdCBDQTAeFw0yNDA2MDcyMjUyNDBaFw0yOTA2MDYyMjUyNDBaMGkxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRIwEAYDVQQHDAlQYWxvIEFsdG8xFTATBgNVBAoMDE9yZ2FuaXphdGlvbjEaMBgGA1UEAwwRTG9jYWxob3N0IFJvb3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDIHMEL9gVSxT/J0qS4xDkDZs1d1UG0+z6NFLLsGdV7gu0ZJbDPlNd0kpjWsisVNB7TcqWoq5ROK5CR+6lZxXC8nbqr2YAJ2O8mHIXcYv7msAN3UYxtM6v1M7K+vNMJdDjZVAxcOKq5R7uUDUPw1weePz6eVEjntAW8mUjqkfnCqYml943Ud3724SkI5wyUT9rKS3bk6hvneq1ah/b1zRGDF2gp+T/oNe4ieS/LGoIUluE2csGRXtt542gpJnw5L54JASmGgt6hunUSWtoaht7Qxv6hYpieu4iHqZY1kfcFDjDH2WI16g1YqrWHzk1l7vWNLVDEcK3kdSQ1GmYAij8ZjAi0LJizLwtN//EkfxiOPlV435itK3uugY+etxrk77BeA6PmVcpZeLLXYuKSrzfaBh0ifP2p0uRlShURi5Rz4IE0I7wHkZ44x9MKYv8YzXK7O29HD158tgorxqwwKmkHqSxWpp7SRKvNnMulHN/el+IKDrPeBhVXsSSkd6U+/H61q7i0SY9TqqhdiMQLW/efK9LkVRen5myhwqogwiF/42Jp2nrCeuzv5YDsAFSrQ0lukW+Hz7FXV+0axnKeXZ08Nd+IS1BhGyMgHo6PWMP1fWyfO0DJVUfIqrHqvBy8bW0yNOuhiyU2oeyDRKv75OMxpIrUeX3qvmrVcYUPvfXsVQIDAQABo1MwUTAdBgNVHQ4EFgQUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wHwYDVR0jBBgwFoAUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEARliSCLdjNI5fFkNwXDK6k6jN5hITrY07XIawUIEwinjQqgLkYFvzXbMtfLwsWmxMPjDVYYDa5Y2NAGcH08b//2z9EuHxMOTOFTKr59BEcVxV1cxV+lspAunH8DLSlLJhf/EeR+MhIIHAfhlE8V7lvlE1EbM+Uj5JYIeefV/4omsGrphyHD3oSJAQDae0su200I/i2yAaTrwXLZ4HtaXsnxKZ4PMPFWaLvMQ8DsLgx2VB3/vQJn74Xepau6mYEWlRnUu90mj79gJOnwBKPlLojF6dJOMIJ2YHr9fI8sUfkVwPFVlkDKJcr0ll5RL3O/naNlLQZuOgijOM5YF5iTrefliVodEHpBPID2mhtq/E+ZIQWLpik8ulsJ8ufN9YfrbjbsiC/KeoMqoFCImRSyMGQDMADo4EV3DNfDFvfrHx0qBMmJ0nkhuGobphegMPCjZ3axvQwQulKuHXmFpAvGYcpK/twBMC1MJkV04tIwVEDZG6id5oKYtrIXHdSFshf6r3z4bbgq6kJnOxZ8Vo4cEw/dgc3hRivr+HnxOJcEk2CTQlCVOiCQAg64OqDEOoswVg6nzoO3RJhFatu+abO22MIXPNGma02zBoQZLYpGzL9z6pMnPKjL15G9H1SYVSTGhmq+GVtdRibg8rLBciSm3ERd7gNRqvYP5GrjCtUIbOTEc=",
-	"target_method": "GET",
-	"target_url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
-	"target_headers": {},
 	"target_body": "",
 	"max_sent_data": 10000,
 	"max_recv_data": 10000,
-	"proving": {
-		"manifest": {
-			"manifestVersion": "1",
-			"id": "reddit-user-karma",
-			"title": "Total Reddit Karma",
-			"description": "Generate a proof that you have a certain amount of karma",
-			"prepareUrl": "https://www.reddit.com/login/",
-			"request": {
-				"method": "GET",
-				"version": "HTTP/1.1",
-				"url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
-				"headers": {
-				},
-				"body": {
-					"userId": "<% userId %>"
-				},
-				"vars": {
-					"userId": {
-						"description": "User ID for authentication",
-						"required": true,
-						"pattern": "[a-z]{,20}+"
-					},
-					"token": {
-						"description": "Authentication token",
-						"required": false,
-						"default": "abcdef1234567890abcdef1234567890",
-						"pattern": "^[A-Za-z0-9]{32}$"
-					}
-				}
+	"manifest": {
+		"manifestVersion": "1",
+		"id": "reddit-user-karma",
+		"title": "Total Reddit Karma",
+		"description": "Generate a proof that you have a certain amount of karma",
+		"prepareUrl": "https://www.reddit.com/login/",
+		"request": {
+			"method": "GET",
+			"url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
+			"headers": {},
+			"body": {
+				"userId": "<% userId %>"
 			},
-			"response": {
-				"status": "200",
-				"version": "HTTP/1.1",
-				"message": "OK",
-				"headers": {
-					"Content-Type": "text/plain; charset=utf-8"
+			"vars": {
+				"userId": {
+					"description": "User ID for authentication",
+					"required": true,
+					"pattern": "[a-z]{,20}+"
 				},
-				"body": {
-					"json": [
-						"hello"
-					],
-					"contains": "world"
+				"token": {
+					"description": "Authentication token",
+					"required": false,
+					"default": "abcdef1234567890abcdef1234567890",
+					"pattern": "^[A-Za-z0-9]{32}$"
 				}
+			}
+		},
+		"response": {
+			"status": "200",
+			"message": "OK",
+			"headers": {
+				"Content-Type": "text/plain; charset=utf-8"
+			},
+			"body": {
+				"json": [
+					"hello"
+				],
+				"contains": "world"
 			}
 		}
 	}

--- a/fixture/client.tee_tcp_local.json
+++ b/fixture/client.tee_tcp_local.json
@@ -3,59 +3,52 @@
 	"notary_host": "localhost",
 	"notary_port": 7443,
 	"notary_ca_cert": "MIIFszCCA5ugAwIBAgIUeXLQmnjeXsHpGji7xA8oJjjw7WwwDQYJKoZIhvcNAQELBQAwaTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExEjAQBgNVBAcMCVBhbG8gQWx0bzEVMBMGA1UECgwMT3JnYW5pemF0aW9uMRowGAYDVQQDDBFMb2NhbGhvc3QgUm9vdCBDQTAeFw0yNDA2MDcyMjUyNDBaFw0yOTA2MDYyMjUyNDBaMGkxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRIwEAYDVQQHDAlQYWxvIEFsdG8xFTATBgNVBAoMDE9yZ2FuaXphdGlvbjEaMBgGA1UEAwwRTG9jYWxob3N0IFJvb3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDIHMEL9gVSxT/J0qS4xDkDZs1d1UG0+z6NFLLsGdV7gu0ZJbDPlNd0kpjWsisVNB7TcqWoq5ROK5CR+6lZxXC8nbqr2YAJ2O8mHIXcYv7msAN3UYxtM6v1M7K+vNMJdDjZVAxcOKq5R7uUDUPw1weePz6eVEjntAW8mUjqkfnCqYml943Ud3724SkI5wyUT9rKS3bk6hvneq1ah/b1zRGDF2gp+T/oNe4ieS/LGoIUluE2csGRXtt542gpJnw5L54JASmGgt6hunUSWtoaht7Qxv6hYpieu4iHqZY1kfcFDjDH2WI16g1YqrWHzk1l7vWNLVDEcK3kdSQ1GmYAij8ZjAi0LJizLwtN//EkfxiOPlV435itK3uugY+etxrk77BeA6PmVcpZeLLXYuKSrzfaBh0ifP2p0uRlShURi5Rz4IE0I7wHkZ44x9MKYv8YzXK7O29HD158tgorxqwwKmkHqSxWpp7SRKvNnMulHN/el+IKDrPeBhVXsSSkd6U+/H61q7i0SY9TqqhdiMQLW/efK9LkVRen5myhwqogwiF/42Jp2nrCeuzv5YDsAFSrQ0lukW+Hz7FXV+0axnKeXZ08Nd+IS1BhGyMgHo6PWMP1fWyfO0DJVUfIqrHqvBy8bW0yNOuhiyU2oeyDRKv75OMxpIrUeX3qvmrVcYUPvfXsVQIDAQABo1MwUTAdBgNVHQ4EFgQUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wHwYDVR0jBBgwFoAUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEARliSCLdjNI5fFkNwXDK6k6jN5hITrY07XIawUIEwinjQqgLkYFvzXbMtfLwsWmxMPjDVYYDa5Y2NAGcH08b//2z9EuHxMOTOFTKr59BEcVxV1cxV+lspAunH8DLSlLJhf/EeR+MhIIHAfhlE8V7lvlE1EbM+Uj5JYIeefV/4omsGrphyHD3oSJAQDae0su200I/i2yAaTrwXLZ4HtaXsnxKZ4PMPFWaLvMQ8DsLgx2VB3/vQJn74Xepau6mYEWlRnUu90mj79gJOnwBKPlLojF6dJOMIJ2YHr9fI8sUfkVwPFVlkDKJcr0ll5RL3O/naNlLQZuOgijOM5YF5iTrefliVodEHpBPID2mhtq/E+ZIQWLpik8ulsJ8ufN9YfrbjbsiC/KeoMqoFCImRSyMGQDMADo4EV3DNfDFvfrHx0qBMmJ0nkhuGobphegMPCjZ3axvQwQulKuHXmFpAvGYcpK/twBMC1MJkV04tIwVEDZG6id5oKYtrIXHdSFshf6r3z4bbgq6kJnOxZ8Vo4cEw/dgc3hRivr+HnxOJcEk2CTQlCVOiCQAg64OqDEOoswVg6nzoO3RJhFatu+abO22MIXPNGma02zBoQZLYpGzL9z6pMnPKjL15G9H1SYVSTGhmq+GVtdRibg8rLBciSm3ERd7gNRqvYP5GrjCtUIbOTEc=",
-	"target_method": "GET",
-	"target_url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
-	"target_headers": {},
 	"target_body": "",
 	"max_sent_data": 10000,
 	"max_recv_data": 10000,
-	"proving": {
-		"manifest": {
-			"manifestVersion": "1",
-			"id": "reddit-user-karma",
-			"title": "Total Reddit Karma",
-			"description": "Generate a proof that you have a certain amount of karma",
-			"prepareUrl": "https://www.reddit.com/login/",
-			"request": {
-				"method": "GET",
-				"version": "HTTP/1.1",
-				"url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
-				"headers": {
-					"accept-encoding": "identity",
-                    "host": "gist.githubusercontent.com",
-                    "connection": "close",
-                    "accept": "*/*"
-				},
-				"body": {
-					"userId": "<% userId %>"
-				},
-				"vars": {
-					"userId": {
-						"description": "User ID for authentication",
-						"required": true,
-						"pattern": "[a-z]{,20}+"
-					},
-					"token": {
-						"description": "Authentication token",
-						"required": false,
-						"default": "abcdef1234567890abcdef1234567890",
-						"pattern": "^[A-Za-z0-9]{32}$"
-					}
-				}
+	"manifest": {
+		"manifestVersion": "1",
+		"id": "reddit-user-karma",
+		"title": "Total Reddit Karma",
+		"description": "Generate a proof that you have a certain amount of karma",
+		"prepareUrl": "https://www.reddit.com/login/",
+		"request": {
+			"method": "GET",
+			"url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
+			"headers": {
+				"accept-encoding": "identity",
+				"host": "gist.githubusercontent.com",
+				"connection": "close",
+				"accept": "*/*"
 			},
-			"response": {
-				"status": "200",
-				"version": "HTTP/1.1",
-				"message": "OK",
-				"headers": {
-					"Content-Type": "text/plain; charset=utf-8"
+			"body": {
+				"userId": "<% userId %>"
+			},
+			"vars": {
+				"userId": {
+					"description": "User ID for authentication",
+					"required": true,
+					"pattern": "[a-z]{,20}+"
 				},
-				"body": {
-					"json": [
-						"hello"
-					],
-					"contains": "world"
+				"token": {
+					"description": "Authentication token",
+					"required": false,
+					"default": "abcdef1234567890abcdef1234567890",
+					"pattern": "^[A-Za-z0-9]{32}$"
 				}
+			}
+		},
+		"response": {
+			"status": "200",
+			"message": "OK",
+			"headers": {
+				"Content-Type": "text/plain; charset=utf-8"
+			},
+			"body": {
+				"json": [
+					"hello"
+				],
+				"contains": "world"
 			}
 		}
 	}

--- a/fixture/client.tlsn_tcp_local.json
+++ b/fixture/client.tlsn_tcp_local.json
@@ -3,52 +3,45 @@
 	"notary_host": "localhost",
 	"notary_port": 7443,
 	"notary_ca_cert": "MIIFszCCA5ugAwIBAgIUeXLQmnjeXsHpGji7xA8oJjjw7WwwDQYJKoZIhvcNAQELBQAwaTELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExEjAQBgNVBAcMCVBhbG8gQWx0bzEVMBMGA1UECgwMT3JnYW5pemF0aW9uMRowGAYDVQQDDBFMb2NhbGhvc3QgUm9vdCBDQTAeFw0yNDA2MDcyMjUyNDBaFw0yOTA2MDYyMjUyNDBaMGkxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRIwEAYDVQQHDAlQYWxvIEFsdG8xFTATBgNVBAoMDE9yZ2FuaXphdGlvbjEaMBgGA1UEAwwRTG9jYWxob3N0IFJvb3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQDIHMEL9gVSxT/J0qS4xDkDZs1d1UG0+z6NFLLsGdV7gu0ZJbDPlNd0kpjWsisVNB7TcqWoq5ROK5CR+6lZxXC8nbqr2YAJ2O8mHIXcYv7msAN3UYxtM6v1M7K+vNMJdDjZVAxcOKq5R7uUDUPw1weePz6eVEjntAW8mUjqkfnCqYml943Ud3724SkI5wyUT9rKS3bk6hvneq1ah/b1zRGDF2gp+T/oNe4ieS/LGoIUluE2csGRXtt542gpJnw5L54JASmGgt6hunUSWtoaht7Qxv6hYpieu4iHqZY1kfcFDjDH2WI16g1YqrWHzk1l7vWNLVDEcK3kdSQ1GmYAij8ZjAi0LJizLwtN//EkfxiOPlV435itK3uugY+etxrk77BeA6PmVcpZeLLXYuKSrzfaBh0ifP2p0uRlShURi5Rz4IE0I7wHkZ44x9MKYv8YzXK7O29HD158tgorxqwwKmkHqSxWpp7SRKvNnMulHN/el+IKDrPeBhVXsSSkd6U+/H61q7i0SY9TqqhdiMQLW/efK9LkVRen5myhwqogwiF/42Jp2nrCeuzv5YDsAFSrQ0lukW+Hz7FXV+0axnKeXZ08Nd+IS1BhGyMgHo6PWMP1fWyfO0DJVUfIqrHqvBy8bW0yNOuhiyU2oeyDRKv75OMxpIrUeX3qvmrVcYUPvfXsVQIDAQABo1MwUTAdBgNVHQ4EFgQUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wHwYDVR0jBBgwFoAUlro6UuKRY+lHZ3T4FQMhoQAJ2a8wDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAgEARliSCLdjNI5fFkNwXDK6k6jN5hITrY07XIawUIEwinjQqgLkYFvzXbMtfLwsWmxMPjDVYYDa5Y2NAGcH08b//2z9EuHxMOTOFTKr59BEcVxV1cxV+lspAunH8DLSlLJhf/EeR+MhIIHAfhlE8V7lvlE1EbM+Uj5JYIeefV/4omsGrphyHD3oSJAQDae0su200I/i2yAaTrwXLZ4HtaXsnxKZ4PMPFWaLvMQ8DsLgx2VB3/vQJn74Xepau6mYEWlRnUu90mj79gJOnwBKPlLojF6dJOMIJ2YHr9fI8sUfkVwPFVlkDKJcr0ll5RL3O/naNlLQZuOgijOM5YF5iTrefliVodEHpBPID2mhtq/E+ZIQWLpik8ulsJ8ufN9YfrbjbsiC/KeoMqoFCImRSyMGQDMADo4EV3DNfDFvfrHx0qBMmJ0nkhuGobphegMPCjZ3axvQwQulKuHXmFpAvGYcpK/twBMC1MJkV04tIwVEDZG6id5oKYtrIXHdSFshf6r3z4bbgq6kJnOxZ8Vo4cEw/dgc3hRivr+HnxOJcEk2CTQlCVOiCQAg64OqDEOoswVg6nzoO3RJhFatu+abO22MIXPNGma02zBoQZLYpGzL9z6pMnPKjL15G9H1SYVSTGhmq+GVtdRibg8rLBciSm3ERd7gNRqvYP5GrjCtUIbOTEc=",
-	"target_method": "GET",
-	"target_url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
-	"target_headers": {},
 	"target_body": "",
 	"max_sent_data": 10000,
 	"max_recv_data": 10000,
-	"proving": {
-		"manifest": {
-			"manifestVersion": "1",
-			"id": "reddit-user-karma",
-			"title": "Total Reddit Karma",
-			"description": "Generate a proof that you have a certain amount of karma",
-			"prepareUrl": "https://www.reddit.com/login/",
-			"request": {
-				"method": "GET",
-				"version": "HTTP/1.1",
-				"url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
-				"headers": {
-					"accept-encoding": "identity"
-				},
-				"body": {
-					"userId": "<% userId %>"
-				},
-				"vars": {
-					"userId": {
-						"regex": "[a-z]{,20}+"
-					},
-					"token": {
-						"type": "base64",
-						"length": 32
-					}
-				}
+	"manifest": {
+		"manifestVersion": "1",
+		"id": "reddit-user-karma",
+		"title": "Total Reddit Karma",
+		"description": "Generate a proof that you have a certain amount of karma",
+		"prepareUrl": "https://www.reddit.com/login/",
+		"request": {
+			"method": "GET",
+			"url": "https://gist.githubusercontent.com/mattes/23e64faadb5fd4b5112f379903d2572e/raw/74e517a60c21a5c11d94fec8b572f68addfade39/example.json",
+			"headers": {
+				"accept-encoding": "identity"
 			},
-			"response": {
-				"status": "200",
-				"version": "HTTP/1.1",
-				"message": "OK",
-				"headers": {
-					"content-type": "text/plain; charset=utf-8"
+			"body": {
+				"userId": "<% userId %>"
+			},
+			"vars": {
+				"userId": {
+					"regex": "[a-z]{,20}+"
 				},
-				"body": {
-					"json": [
-						"hello"
-					],
-					"contains": "this_string_exists_in_body"
+				"token": {
+					"type": "base64",
+					"length": 32
 				}
+			}
+		},
+		"response": {
+			"status": "200",
+			"message": "OK",
+			"headers": {
+				"content-type": "text/plain; charset=utf-8"
+			},
+			"body": {
+				"json": [
+					"hello"
+				],
+				"contains": "this_string_exists_in_body"
 			}
 		}
 	}


### PR DESCRIPTION
## Related Issues

<!-- Link to issues this PR addresses -->

- Closes #515 

## Summary

<!-- Provide a concise description of the changes (2-3 sentences) -->
Removes redundant variables from manifest, and reuses manifest request.
- removes:
  - target_method
  - target_url
  - target_headers
- proving.manifest.{request,response}.version
- Pull Option<Manifest> as Manifest out of ProvingData
- Remove ProvingData abstraction

## Required Reviews

Minimum number of reviews before merge: **1**
<!-- Mention specific team members if applicable -->

## TODO
Didn't remove `target_body`, it's not used anywhere in web prover, but is used client side
