### PR TITLE
feat!: Use manifest-extracted values in to produce a proof

### DIFF
--- a/core/src/hash.rs
+++ b/core/src/hash.rs
@@ -1,0 +1,11 @@
+use tiny_keccak::{Hasher, Keccak};
+
+pub fn keccak_digest(bytes: &[u8]) -> [u8; 32] {
+  let mut hasher = Keccak::v256();
+  let mut output = [0u8; 32];
+
+  hasher.update(&bytes);
+  hasher.finalize(&mut output);
+
+  output
+}

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -681,11 +681,11 @@ pub mod tests {
             body: ManifestResponseBody {
                 0: ExtractorConfig {
                     format: DataFormat::Json,
-                    extractors: vec![crate::parser::Extractor {
+                    extractors: vec![$crate::parser::Extractor {
                       id: "dummy".to_string(),
                       description: "Dummy extractor".to_string(),
                       selector: vec![],
-                      extractor_type: crate::parser::ExtractorType::String,
+                      extractor_type: $crate::parser::ExtractorType::String,
                       required: true,
                       predicates: vec![],
                       attribute: None,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod error;
 pub mod http;
 pub mod manifest;
 
+pub mod hash;
 pub mod parser;
 pub mod proof;
 pub mod template;

--- a/core/src/manifest.rs
+++ b/core/src/manifest.rs
@@ -2,11 +2,11 @@ use std::fmt;
 
 use derive_more::From;
 use serde::{Deserialize, Serialize};
-use tiny_keccak::{Hasher, Keccak};
 use tracing::debug;
 
 use crate::{
   error::WebProverCoreError,
+  hash::keccak_digest,
   http::{ManifestRequest, ManifestResponse, NotaryResponse},
   parser::{ExtractionResult, ExtractionValues},
 };
@@ -152,6 +152,10 @@ impl ManifestValidationResult {
     );
     self.errors.push(error.to_string());
   }
+
+  pub fn extraction_keccak_digest(&self) -> Result<[u8; 32], WebProverCoreError> {
+    Ok(self.extraction_result.to_keccak_digest()?)
+  }
 }
 
 /// Manifest containing [`ManifestRequest`] and [`ManifestResponse`]
@@ -217,13 +221,7 @@ impl Manifest {
   /// Compute a `Keccak256` hash of the serialized Manifest
   pub fn to_keccak_digest(&self) -> Result<[u8; 32], WebProverCoreError> {
     let as_bytes: Vec<u8> = self.try_into()?;
-    let mut hasher = Keccak::v256();
-    let mut output = [0u8; 32];
-
-    hasher.update(&as_bytes);
-    hasher.finalize(&mut output);
-
-    Ok(output)
+    Ok(keccak_digest(&as_bytes))
   }
 }
 

--- a/core/src/parser/config.rs
+++ b/core/src/parser/config.rs
@@ -180,7 +180,7 @@ mod tests {
     assert_eq!(extractor1.description, "Extract user's name");
     assert_eq!(extractor1.selector, vec!["user", "name"]);
     assert_eq!(extractor1.extractor_type, ExtractorType::String);
-    assert_eq!(extractor1.required, true);
+    assert!(extractor1.required);
     assert_eq!(extractor1.predicates.len(), 1);
 
     let predicate1 = &extractor1.predicates[0];
@@ -193,7 +193,7 @@ mod tests {
     assert_eq!(extractor2.description, "Extract user's age");
     assert_eq!(extractor2.selector, vec!["user", "age"]);
     assert_eq!(extractor2.extractor_type, ExtractorType::Number);
-    assert_eq!(extractor2.required, true);
+    assert!(extractor2.required);
     assert_eq!(extractor2.predicates.len(), 1);
 
     let predicate2 = &extractor2.predicates[0];
@@ -241,7 +241,7 @@ mod tests {
     assert_eq!(extractor.id, "userAge");
     assert_eq!(extractor.selector, vec!["user", "age"]);
     assert_eq!(extractor.extractor_type, ExtractorType::Number);
-    assert_eq!(extractor.required, true);
+    assert!(extractor.required);
 
     let predicate = &extractor.predicates[0];
     assert_eq!(predicate.predicate_type, PredicateType::Value);

--- a/core/src/parser/extractors/html.rs
+++ b/core/src/parser/extractors/html.rs
@@ -407,7 +407,7 @@ mod tests {
 
   #[test]
   fn test_html_extract_basic_text() {
-    let dom = parse_html(&BASIC_HTML);
+    let dom = parse_html(BASIC_HTML);
     assert_html_extraction(
       &dom,
       &["#main-title".to_string()],
@@ -419,7 +419,7 @@ mod tests {
 
   #[test]
   fn test_html_extraction_errors() {
-    let dom = parse_html(&BASIC_HTML);
+    let dom = parse_html(BASIC_HTML);
     let basic_extractor = extractor!(
       id: "test".to_string(),
       description: "Test extractor".to_string(),

--- a/core/src/parser/extractors/types.rs
+++ b/core/src/parser/extractors/types.rs
@@ -8,9 +8,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::debug;
 
-use crate::parser::{
-  errors::ExtractorErrorWithId, extractors::get_value_type, predicate, predicate::Predicate,
-  DataFormat, ExtractorConfig, ExtractorError,
+use crate::{
+  hash::keccak_digest,
+  parser::{
+    errors::ExtractorErrorWithId, extractors::get_value_type, predicate, predicate::Predicate,
+    DataFormat, ExtractorConfig, ExtractorError,
+  },
 };
 
 /// Trait for extracting data from a document
@@ -200,6 +203,12 @@ impl ExtractionResult {
 
   /// Returns `true` if no errors were encountered during extraction
   pub fn is_success(&self) -> bool { self.errors.is_empty() }
+
+  /// Compute a `Keccak256` hash of the serialized ExtractionResult
+  pub fn to_keccak_digest(&self) -> Result<[u8; 32], ExtractorError> {
+    let as_bytes: Vec<u8> = serde_json::to_vec(self)?;
+    Ok(keccak_digest(&as_bytes))
+  }
 }
 
 /// The value extracted from the raw document

--- a/core/src/parser/test_utils.rs
+++ b/core/src/parser/test_utils.rs
@@ -18,11 +18,11 @@ pub fn create_json_config(extractors: Vec<Extractor>) -> ExtractorConfig {
 macro_rules! extractor {
     // Match with optional parameters
     ($($key:ident: $value:expr),* $(,)?) => {{
-        let mut extractor = crate::parser::Extractor {
+        let mut extractor = $crate::parser::Extractor {
             id: String::new(),
             description: String::new(),
             selector: Vec::new(),
-            extractor_type: crate::parser::ExtractorType::String,
+            extractor_type: $crate::parser::ExtractorType::String,
             required: true,
             predicates: Vec::new(),
             attribute: None,
@@ -70,9 +70,9 @@ pub fn assert_extraction_error(
 macro_rules! predicate {
         // Match with optional parameters
         ($($key:ident: $value:expr),* $(,)?) => {{
-            let mut predicate = crate::parser::predicate::Predicate {
-                predicate_type: crate::parser::predicate::PredicateType::Value,
-                comparison: crate::parser::predicate::Comparison::Equal,
+            let mut predicate = $crate::parser::predicate::Predicate {
+                predicate_type: $crate::parser::predicate::PredicateType::Value,
+                comparison: $crate::parser::predicate::Comparison::Equal,
                 value: serde_json::Value::Null,
                 case_sensitive: true,
                 flags: None,

--- a/notary/src/error.rs
+++ b/notary/src/error.rs
@@ -44,9 +44,6 @@ pub enum NotaryServerError {
   #[error("Error occurred from reasing server config: {0}")]
   ServerConfigError(String),
 
-  #[error("Manifest-request mismatch")]
-  ManifestRequestMismatch,
-
   #[error(transparent)]
   ProxyError(#[from] ProxyError),
 


### PR DESCRIPTION
## Related Issues

- Fixes #543

## Summary

- Since the original issue experienced significant scope drift, this PR is limited to simply updating the proof structure

## Changes

- The signature in `TeeProof` is now made using combined `h([h(manifest), h(extracted_values)])`

## Breaking Changes

- This is a breaking change for the current proof verifier

## Required Reviews

Minimum number of reviews before merge: **1**

CC: @0xFloyd 

