### PR TITLE
feat!: Enforce Manifest versioning

### DIFF
--- a/core/src/hash.rs
+++ b/core/src/hash.rs
@@ -4,7 +4,7 @@ pub fn keccak_digest(bytes: &[u8]) -> [u8; 32] {
   let mut hasher = Keccak::v256();
   let mut output = [0u8; 32];
 
-  hasher.update(&bytes);
+  hasher.update(bytes);
   hasher.finalize(&mut output);
 
   output

--- a/core/src/test_utils.rs
+++ b/core/src/test_utils.rs
@@ -1,6 +1,6 @@
 pub const TEST_MANIFEST: &str = r#"
 {
-    "manifestVersion": "1",
+    "manifestVersion": "2",
     "id": "reddit-user-karma",
     "title": "Total Reddit Karma",
     "description": "Generate a proof that you have a certain amount of karma",

--- a/fixture/client.html.tee_tcp_local.json
+++ b/fixture/client.html.tee_tcp_local.json
@@ -11,7 +11,7 @@
   "max_recv_data": 10000,
   "proving": {
     "manifest": {
-      "manifestVersion": "1",
+      "manifestVersion": "2",
       "id": "wikipedia-claude-shannon",
       "title": "Wikipedia Claude Shannon",
       "description": "Generate a proof that you have visited the Claude Shannon Wikipedia page",


### PR DESCRIPTION
## Related Issues

- Afterthought from #541 

## Summary

- Manifest v1 is now deprecated
- The new currently supported and enforced Manifest version is `2`
- Manifests with other versions will fail validation from now on

## Required Reviews

Minimum number of reviews before merge: **1**


